### PR TITLE
problems with reset_perishable_token! and save(false)

### DIFF
--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -277,7 +277,7 @@ module Authlogic
           # Resets the password to a random friendly token and then saves the record.
           def reset_password!
             reset_password
-            save_without_session_maintenance(false)
+            save_without_session_maintenance(:validate => false)
           end
           alias_method :randomize_password!, :reset_password!
         

--- a/lib/authlogic/acts_as_authentic/perishable_token.rb
+++ b/lib/authlogic/acts_as_authentic/perishable_token.rb
@@ -91,7 +91,7 @@ module Authlogic
           # Same as reset_perishable_token, but then saves the record afterwards.
           def reset_perishable_token!
             reset_perishable_token
-            save_without_session_maintenance(false)
+            save_without_session_maintenance(:validate => false)
           end
           
           # A convenience method based on the disable_perishable_token_maintenance configuration option.

--- a/lib/authlogic/acts_as_authentic/persistence_token.rb
+++ b/lib/authlogic/acts_as_authentic/persistence_token.rb
@@ -53,7 +53,7 @@ module Authlogic
           # Same as reset_persistence_token, but then saves the record.
           def reset_persistence_token!
             reset_persistence_token
-            save_without_session_maintenance(false)
+            save_without_session_maintenance(:validate => false)
           end
           alias_method :forget!, :reset_persistence_token!
           

--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -92,7 +92,7 @@ module Authlogic
         
         def save_record(alternate_record = nil)
           r = alternate_record || record
-          r.save_without_session_maintenance(false) if r && r.changed? && !r.readonly?
+          r.save_without_session_maintenance(:validate => false) if r && r.changed? && !r.readonly?
         end
     end
   end


### PR DESCRIPTION
Hi!

Recently I've tried to use your tutorial http://www.binarylogic.com/2008/11/16/tutorial-reset-passwords-with-authlogic/ to add passwords reset functionality to my Rails3 project. But while using function reset_perishable_token! I have founded depricated functionallity with ActiveRecord::Base#save(false) function:

one of my errors.
DEPRECATION WARNING: save(false) is deprecated, please give save(:validate => false) instead....

So I forked repository and added a patch. :)

Please, add it to main repository and make a new version of authlogic gem, so I wouldn't have to mess with that inside my code. 

Cheers,
Rafal.
