### PR TITLE
Allow use of authenticate_or_request_with_http_basic

### DIFF
--- a/lib/authlogic/test_case/mock_controller.rb
+++ b/lib/authlogic/test_case/mock_controller.rb
@@ -3,7 +3,7 @@ module Authlogic
     # Basically acts like a controller but doesn't do anything. Authlogic can interact with this, do it's thing and then you
     # can look at the controller object to see if anything changed.
     class MockController < ControllerAdapters::AbstractAdapter
-      attr_accessor :http_user, :http_password
+      attr_accessor :http_user, :http_password, :realm
       attr_writer :request_content_type
   
       def initialize
@@ -13,6 +13,12 @@ module Authlogic
         yield http_user, http_password
       end
   
+      def authenticate_or_request_with_http_basic(realm = 'DefaultRealm', &block)
+        self.realm = realm
+        @http_auth_requested = true
+        yield http_user, http_password
+      end
+
       def cookies
         @cookies ||= MockCookieJar.new
       end
@@ -39,6 +45,10 @@ module Authlogic
   
       def session
         @session ||= {}
+      end
+
+      def http_auth_requested?
+        @http_auth_requested ||= false
       end
     end
   end

--- a/test/session_test/http_auth_test.rb
+++ b/test/session_test/http_auth_test.rb
@@ -10,17 +10,45 @@ module SessionTest
         UserSession.allow_http_basic_auth true
         assert_equal true, UserSession.allow_http_basic_auth
       end
+
+      def test_request_http_basic_auth
+        UserSession.request_http_basic_auth = true
+        assert_equal true, UserSession.request_http_basic_auth
+
+        UserSession.request_http_basic_auth = false
+        assert_equal false, UserSession.request_http_basic_auth
+      end
+
+      def test_http_basic_auth_realm
+        assert_equal 'Application', UserSession.http_basic_auth_realm
+
+        UserSession.http_basic_auth_realm = 'TestRealm'
+        assert_equal 'TestRealm', UserSession.http_basic_auth_realm
+      end
     end
     
     class InstanceMethodsTest < ActiveSupport::TestCase
       def test_persist_persist_by_http_auth
         ben = users(:ben)
-        http_basic_auth_for { assert !UserSession.find }
+        http_basic_auth_for do
+          assert !UserSession.find
+        end
         http_basic_auth_for(ben) do
           assert session = UserSession.find
           assert_equal ben, session.record
           assert_equal ben.login, session.login
           assert_equal "benrocks", session.send(:protected_password)
+          assert !controller.http_auth_requested?
+        end
+        UserSession.request_http_basic_auth = true
+        UserSession.http_basic_auth_realm = 'PersistTestRealm'
+        http_basic_auth_for(ben) do
+          assert session = UserSession.find
+          assert_equal ben, session.record
+          assert_equal ben.login, session.login
+          assert_equal "benrocks", session.send(:protected_password)
+          assert_equal 'PersistTestRealm', controller.realm
+          assert controller.http_auth_requested?
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -144,7 +144,7 @@ class ActiveSupport::TestCase
         controller.http_password = password_for(user)
       end
       yield
-      controller.http_user = controller.http_password = nil
+      controller.http_user = controller.http_password = controller.realm = nil
     end
     
     def set_cookie_for(user, id = nil)


### PR DESCRIPTION
This allows the optional use of the Rails controller method `authenticate_or_request_with_http_basic` instead of `authenticate_with_http_basic`.  This will allow the use of the classic HTTP authentication browser popup, which is currently not possible without bypassing authlogic.

Also adds another config option to set the HTTP authentication realm.

The default HTTP auth behaviour should remain unaffected.
