### PR TITLE
Yet another fix for the (save) deprecation warnings.

### DIFF
--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -69,6 +69,11 @@ module Authlogic
         
         # Save the record and skip session maintenance all together.
         def save_without_session_maintenance(*args)
+          if defined?(::ActiveModel) && [true,false].include?(args.first)
+            validate = args.shift
+            args << {} if args.empty?
+            args[0][:validate] = validate
+          end
           self.skip_session_maintenance = true
           result = save(*args)
           self.skip_session_maintenance = false


### PR DESCRIPTION
Tests run fine with this one. Takes Rails2 compatibility into account. Doesn't matter to me which one of the fixes that have been requested gets pulled, as long as one does sometime soon. Thanks!
