### PR TITLE
New Javascript API and connect to existing users

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -67,6 +67,7 @@ If you find a bug or a problem please post it in the issues section. If you need
 * <b>Authlogic OpenID addon:</b> http://github.com/binarylogic/authlogic_openid
 * <b>Authlogic LDAP addon:</b> http://github.com/binarylogic/authlogic_ldap
 * <b>Authlogic Facebook Connect:</b> http://github.com/kalasjocke/authlogic_facebook_connect
+* <b>Authlogic Facebook Connect (New JS API):</b> http://github.com/studybyte/authlogic_facebook_connect
 * <b>Authlogic OAuth (Twitter):</b> http://github.com/jrallison/authlogic_oauth
 * <b>Authlogic PAM:</b> http://github.com/nbudin/authlogic_pam
 


### PR DESCRIPTION
This is a fork of the existing Facebook connect plugin, It uses the new JS API which allows you to request additional permissions at the initial connection with facebook. It also supports connecting with existing users of the application.
