### PR TITLE
Quotes may also be part of the email name

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -10,7 +10,7 @@ module Authlogic
     # for regular expressions.
     def self.email
       return @email_regex if @email_regex
-      email_name_regex  = '[A-Z0-9_\.%\+\-]+'
+      email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
       domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
       domain_tld_regex  = '(?:[A-Z]{2,4}|museum|travel)'
       @email_regex = /^#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}$/i

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -81,6 +81,10 @@ module ActsAsAuthenticTest
       u.email = "dakota.dux+1@gmail.com"
       u.valid?
       assert u.errors[:email].size == 0
+
+      u.email = "a'quote@mydomain.com"
+      u.valid?
+      assert u.errors[:email].size == 0
     end
     
     def test_validates_uniqueness_of_email_field


### PR DESCRIPTION
I just ran into an account that had a single quote as part of the email name. According to my reading of RFC 2822 this is indeed valid, so I've changed the email name regex to match this.
