### PR TITLE
Fixed deprecation warnings in rails3

### DIFF
--- a/lib/authlogic/acts_as_authentic/logged_in_status.rb
+++ b/lib/authlogic/acts_as_authentic/logged_in_status.rb
@@ -32,8 +32,8 @@ module Authlogic
           klass.class_eval do
             include InstanceMethods
             
-            named_scope :logged_in, lambda { {:conditions => ["last_request_at > ?", logged_in_timeout.seconds.ago]} }
-            named_scope :logged_out, lambda { {:conditions => ["last_request_at is NULL or last_request_at <= ?", logged_in_timeout.seconds.ago]} }
+            scope :logged_in, lambda { {:conditions => ["last_request_at > ?", logged_in_timeout.seconds.ago]} }
+            scope :logged_out, lambda { {:conditions => ["last_request_at is NULL or last_request_at <= ?", logged_in_timeout.seconds.ago]} }
           end
         end
         


### PR DESCRIPTION
Hi,

This patch should fix deprecation warnings in rails3

```
DEPRECATION WARNING: Base.named_scope has been deprecated, please use Base.scope instead.
```

Cheers,
Adrian Dulić
