### PR TITLE
Allow 3.1 Rails usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem 'activerecord', '~> 3.0.7'
+gem 'activerecord', '>= 3.0.7'
 
 group :test do
   gem 'bcrypt-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 3.0.7)
+  activerecord (>= 3.0.7)
   bcrypt-ruby
   jeweler
   ruby-debug19

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -206,15 +206,15 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activerecord>, ["~> 3.0.7"])
-      s.add_runtime_dependency(%q<activerecord>, ["~> 3.0.7"])
+      s.add_runtime_dependency(%q<activerecord>, [">= 3.0.7"])
+      s.add_runtime_dependency(%q<activerecord>, [">= 3.0.7"])
     else
-      s.add_dependency(%q<activerecord>, ["~> 3.0.7"])
-      s.add_dependency(%q<activerecord>, ["~> 3.0.7"])
+      s.add_dependency(%q<activerecord>, [">= 3.0.7"])
+      s.add_dependency(%q<activerecord>, [">= 3.0.7"])
     end
   else
-    s.add_dependency(%q<activerecord>, ["~> 3.0.7"])
-    s.add_dependency(%q<activerecord>, ["~> 3.0.7"])
+    s.add_dependency(%q<activerecord>, [">= 3.0.7"])
+    s.add_dependency(%q<activerecord>, [">= 3.0.7"])
   end
 end
 


### PR DESCRIPTION
This allows any version above 3.0.7 to be used with Authlogic. I.e the 3.1  beta
