### PR TITLE
Using implicit return so request_http_basic_auth works when invalid credentials are entered, fixes #265.

### DIFF
--- a/lib/authlogic/session/http_auth.rb
+++ b/lib/authlogic/session/http_auth.rb
@@ -77,7 +77,7 @@ module Authlogic
               if !login.blank? && !password.blank?
                 send("#{login_field}=", login)
                 send("#{password_field}=", password)
-                return valid?
+                valid?
               end
             end
 


### PR DESCRIPTION
Using implicit return so request_http_basic_auth works when invalid credentials are entered, fixes #265.
