### PR TITLE
Hi Dear

### DIFF
--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -165,7 +165,7 @@ module Authlogic
           
           def save_cookie
             controller.cookies[cookie_key] = {
-              :value => "#{record.persistence_token}::#{record.send(record.class.primary_key)}",
+              :value => "#{record.persistence_token}",
               :expires => remember_me_until,
               :secure => secure,
               :httponly => httponly,

--- a/test/session_test/cookies_test.rb
+++ b/test/session_test/cookies_test.rb
@@ -120,7 +120,7 @@ module SessionTest
         ben = users(:ben)
         session = UserSession.new(ben)
         assert session.save
-        assert_equal "#{ben.persistence_token}::#{ben.id}", controller.cookies["user_credentials"]
+        assert_equal "#{ben.persistence_token}", controller.cookies["user_credentials"]
       end
     
       def test_after_destroy_destroy_cookie


### PR DESCRIPTION
I just did a single sign on with Authlogic by simply sharing the cookie. It's so simple and cool. Once you logged into a single application, you logged into all applications.

I don't want to share database between my applications, so I synchronize user data to all applications that have their own database.

I can easily synchronize all user data (persistence_token, login and crypted_password) between my applications, but id(primary key) because the id is special and increased by the sequence automatically. so that the same user with same login and persistence_token has different id in different application.

So please do not store the primary key in cookies. I think persistence_token works so good, why do we still need to store primary key?
