### PR TITLE
Make password_field configurable

### DIFF
--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -13,6 +13,23 @@ module Authlogic
       
       # All configuration for the password aspect of acts_as_authentic.
       module Config
+        # The name of the virtual password field, used for setting the password.
+        #
+        # * <tt>Default:</tt> :password
+        # * <tt>Accepts:</tt> Symbol
+        def password_field(value = nil)
+          rw_config(:password_field, value, :password)
+        end
+        alias_method :password_field=, :password_field
+        
+        # The name of the virtual password confirmation field, used for setting the password.
+        # The value of this field is "#{password_field}_confirmation", and is not configurable.
+        #
+        # * <tt>Default:</tt> :password_confirmation
+        def password_confirmation_field()
+          rw_config(:password_confirmation_field, nil, "#{password_field}_confirmation".to_sym)
+        end
+        
         # The name of the crypted_password field in the database.
         #
         # * <tt>Default:</tt> :crypted_password, :encrypted_password, :password_hash, or :pw_hash
@@ -212,36 +229,36 @@ module Authlogic
             include InstanceMethods
             
             if validate_password_field
-              validates_length_of :password, validates_length_of_password_field_options
+              validates_length_of password_field, validates_length_of_password_field_options
               
               if require_password_confirmation
-                validates_confirmation_of :password, validates_confirmation_of_password_field_options
-                validates_length_of :password_confirmation, validates_length_of_password_confirmation_field_options
+                validates_confirmation_of password_field, validates_confirmation_of_password_field_options
+                validates_length_of "#{password_confirmation_field}", validates_length_of_password_confirmation_field_options
               end
             end
             
             after_save :reset_password_changed
+
+            # The password
+            define_method password_field do
+              @password
+            end
+        
+            # This is a virtual method. Once a password is passed to it, it will create new password salt as well as encrypt
+            # the password.
+            define_method "#{password_field}=" do |pass|
+              return if ignore_blank_passwords? && pass.blank?
+              before_password_set
+              @password = pass
+              send("#{password_salt_field}=", Authlogic::Random.friendly_token) if password_salt_field
+              send("#{crypted_password_field}=", crypto_provider.encrypt(*encrypt_arguments(@password, false, act_like_restful_authentication? ? :restful_authentication : nil)))
+              @password_changed = true
+              after_password_set
+            end
           end
         end
         
         module InstanceMethods
-          # The password
-          def password
-            @password
-          end
-        
-          # This is a virtual method. Once a password is passed to it, it will create new password salt as well as encrypt
-          # the password.
-          def password=(pass)
-            return if ignore_blank_passwords? && pass.blank?
-            before_password_set
-            @password = pass
-            send("#{password_salt_field}=", Authlogic::Random.friendly_token) if password_salt_field
-            send("#{crypted_password_field}=", crypto_provider.encrypt(*encrypt_arguments(@password, false, act_like_restful_authentication? ? :restful_authentication : nil)))
-            @password_changed = true
-            after_password_set
-          end
-        
           # Accepts a raw password to determine if it is the correct password or not. Notice the second argument. That defaults to the value of
           # check_passwords_against_database. See that method for mor information, but basically it just tells Authlogic to check the password
           # against the value in the database or the value in the object.
@@ -269,8 +286,8 @@ module Authlogic
           # Resets the password to a random friendly token.
           def reset_password
             friendly_token = Authlogic::Random.friendly_token
-            self.password = friendly_token
-            self.password_confirmation = friendly_token
+            self.send("#{password_field}=", friendly_token)
+            self.send("#{password_confirmation_field}=", friendly_token)
           end
           alias_method :randomize_password, :reset_password
         
@@ -313,7 +330,7 @@ module Authlogic
             end
             
             def transition_password(attempted_password)
-              self.password = attempted_password
+              self.send("#{password_field}=", attempted_password)
               save(:validate => false)
             end
           
@@ -331,6 +348,14 @@ module Authlogic
             
             def reset_password_changed
               @password_changed = nil
+            end
+          
+            def password_field
+              self.class.password_field
+            end
+          
+            def password_confirmation_field
+              self.class.password_confirmation_field
             end
           
             def crypted_password_field

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -2,6 +2,15 @@ require 'test_helper'
 
 module ActsAsAuthenticTest
   class PasswordTest < ActiveSupport::TestCase
+    def test_password_field_config
+      User.password_field = :nope
+      assert_equal :nope, User.password_field
+      assert_equal :nope_confirmation, User.password_confirmation_field
+      User.password_field :password
+      assert_equal :password, User.password_field
+      assert_equal :password_confirmation, User.password_confirmation_field
+    end
+    
     def test_crypted_password_field_config
       assert_equal :crypted_password, User.crypted_password_field
       assert_equal :crypted_password, Employee.crypted_password_field
@@ -105,47 +114,47 @@ module ActsAsAuthenticTest
     
     def test_validates_length_of_password
       u = User.new
-      u.password_confirmation = "test2"
+      u.send("#{User.password_confirmation_field}=", "test2")
       assert !u.valid?
-      assert u.errors[:password].size > 0
+      assert u.errors[User.password_field].size > 0
       
-      u.password = "test"
+      u.send("#{User.password_field}=", "test")
       assert !u.valid?
-      assert u.errors[:password_confirmation].size == 0
+      assert u.errors[User.password_confirmation_field].size == 0
     end
     
     def test_validates_confirmation_of_password
       u = User.new
-      u.password = "test"
-      u.password_confirmation = "test2"
+      u.send("#{User.password_field}=", "test")
+      u.send("#{User.password_confirmation_field}=", "test2")
       assert !u.valid?
-      assert u.errors[:password].size > 0
+      assert u.errors[User.password_field].size > 0
       
       u.password_confirmation = "test"
       assert !u.valid?
-      assert u.errors[:password].size == 0
+      assert u.errors[User.password_field].size == 0
     end
     
     def test_validates_length_of_password_confirmation
       u = User.new
       
-      u.password = "test"
-      u.password_confirmation = ""
+      u.send("#{User.password_field}=", "test")
+      u.send("#{User.password_confirmation_field}=", "")
       assert !u.valid?
-      assert u.errors[:password_confirmation].size > 0
+      assert u.errors[User.password_confirmation_field].size > 0
       
       u.password_confirmation = "test"
       assert !u.valid?
-      assert u.errors[:password_confirmation].size == 0
+      assert u.errors[User.password_confirmation_field].size == 0
       
       ben = users(:ben)
       assert ben.valid?
       
-      ben.password = "newpass"
+      ben.send("#{User.password_field}=", "newpass")
       assert !ben.valid?
-      assert ben.errors[:password_confirmation].size > 0
+      assert ben.errors[User.password_confirmation_field].size > 0
       
-      ben.password_confirmation = "newpass"
+      ben.send("#{User.password_confirmation_field}=", "newpass")
       assert ben.valid?
     end
     
@@ -153,7 +162,7 @@ module ActsAsAuthenticTest
       u = User.new
       old_password_salt = u.password_salt
       old_crypted_password = u.crypted_password
-      u.password = "test"
+      u.send("#{User.password_field}=", "test")
       assert_not_equal old_password_salt, u.password_salt
       assert_not_equal old_crypted_password, u.crypted_password
     end
@@ -167,20 +176,20 @@ module ActsAsAuthenticTest
     
     def test_checks_password_against_database
       ben = users(:ben)
-      ben.password = "new pass"
+      ben.send("#{User.password_field}=", "new pass")
       assert !ben.valid_password?("new pass")
       assert ben.valid_password?("benrocks")
     end
     
     def test_checks_password_against_database_and_always_fails_on_new_records
       user = User.new
-      user.password = "new pass"
+      user.send("#{User.password_field}=", "new pass")
       assert !user.valid_password?("new pass")
     end
     
     def test_checks_password_against_object
       ben = users(:ben)
-      ben.password = "new pass"
+      ben.send("#{User.password_field}=", "new pass")
       assert ben.valid_password?("new pass", false)
       assert !ben.valid_password?("benrocks", false)
     end


### PR DESCRIPTION
We had a (poor) database schema that stored the crypted_password in a field named "password", and used clear_password and clear_password_confirmation for setting the password. Since authlogic hard codes the password field, we were unable to use authlogic without changing our db schema. That would be nice to make it something more sane, but it would also prevent us from using any of the other branches of our app (not an option).

This patch makes the password_field configurable.
