### PR TITLE
Use klass_name for cookie_key, since klass_name falls back to guessed_klass_name anyway.

### DIFF
--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -23,10 +23,10 @@ module Authlogic
         #   session = UserSession.new(:super_high_secret)
         #   session.cookie_key => "super_high_secret_user_credentials"
         #
-        # * <tt>Default:</tt> "#{guessed_klass_name.underscore}_credentials"
+        # * <tt>Default:</tt> "#{klass_name.underscore}_credentials"
         # * <tt>Accepts:</tt> String
         def cookie_key(value = nil)
-          rw_config(:cookie_key, value, "#{guessed_klass_name.underscore}_credentials")
+          rw_config(:cookie_key, value, "#{klass_name.underscore}_credentials")
         end
         alias_method :cookie_key=, :cookie_key
         


### PR DESCRIPTION
Use `klass_name` for `cookie_key`, since it falls back to `guessed_klass_name` anyway. Otherwise an `undefined method 'underscore' for nil:NilClass` error is thrown when the session authentication class does not follow the `{Model}Session` naming convention.

We believe this is more appropriate logic, considering the docs for the `klass` method in the `Config` module:

> The name of the class that this session is authenticating with. For example, the UserSession class will authenticate with the User class unless you specify otherwise in your configuration. See authenticate_with for information on how to change this value.
