### PR TITLE
Add general_credentials_error to the list of used I18n keys

### DIFF
--- a/lib/authlogic/i18n.rb
+++ b/lib/authlogic/i18n.rb
@@ -40,6 +40,7 @@ module Authlogic
   #       not_confirmed: Your account is not confirmed
   #       not_approved: Your account is not approved
   #       no_authentication_details: You did not provide any details for authentication.
+  #       general_credentials_error: Login/Password combination is not valid
   #     models:
   #       user_session: UserSession (or whatever name you are using)
   #     attributes:


### PR DESCRIPTION
It is used in /lib/authlogic/session/password.rb, but was not listed in the comments of i18n.rb

I ran into this when localizing a Rails app, and it's been undocumented for a while, so I thought I'd fix this.
This is my first pull request on github, so I'm sorry if anything's wrong/missing :)
