### PR TITLE
Raise an exception if database connection is not established before using acts_as_authentic

### DIFF
--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -28,7 +28,7 @@ module Authlogic
         # See the various sub modules for the configuration they provide.
         def acts_as_authentic(unsupported_options = nil, &block)
           # Stop all configuration if the DB is not set up
-          return if !db_setup?
+          raise StandardError.new("You must establish a database connection before using acts_as_authentic") if !db_setup?
           
           raise ArgumentError.new("You are using the old v1.X.X configuration method for Authlogic. Instead of " +
             "passing a hash of configuration options to acts_as_authentic, pass a block: acts_as_authentic { |c| c.my_option = my_value }") if !unsupported_options.nil?


### PR DESCRIPTION
This would have helped us resolve an issue that took quite a while to debug because we didn't receive a meaningful exception message.

We are using Authlogic in a Sinatra based app and were including the model that uses acts_as_authentic before we established the database connection.  Currently, instead of raising an exception the acts_as_authentic method just returns without error.  A few lines later when we called:

``` ruby
if user.valid_password?(password)
```

which resulted in the exception:

_undefined method `valid_password?' for #&lt;User:0x007fd29dd269b0&gt;_

since the model wasn't initialized with the Authlogic modules.
