### PR TITLE
Lambda wrapped authentic #logged_in & #logged_out scopes

### DIFF
--- a/lib/authlogic/acts_as_authentic/logged_in_status.rb
+++ b/lib/authlogic/acts_as_authentic/logged_in_status.rb
@@ -31,8 +31,8 @@ module Authlogic
 
           klass.class_eval do
             include InstanceMethods
-            scope :logged_in, where("last_request_at > ?", logged_in_timeout.seconds.ago)
-            scope :logged_out, where("last_request_at is NULL or last_request_at <= ?", logged_in_timeout.seconds.ago)
+            scope :logged_in, lambda{ where("last_request_at > ?", logged_in_timeout.seconds.ago) }
+            scope :logged_out, lambda{ where("last_request_at is NULL or last_request_at <= ?", logged_in_timeout.seconds.ago) }
           end
         end
 

--- a/test/acts_as_authentic_test/logged_in_status_test.rb
+++ b/test/acts_as_authentic_test/logged_in_status_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 module ActsAsAuthenticTest
   class LoggedInStatusTest < ActiveSupport::TestCase
+    ERROR_MSG = 'Multiple calls to %s should result in different relations'
+    
     def test_logged_in_timeout_config
       assert_equal 10.minutes.to_i, User.logged_in_timeout
       assert_equal 10.minutes.to_i, Employee.logged_in_timeout
@@ -13,12 +15,24 @@ module ActsAsAuthenticTest
     end
     
     def test_named_scope_logged_in
+      # Testing that the scope returned differs, because the time it was called should be 
+      # slightly different. This is an attempt to make sure the scope is lambda wrapped 
+      # so that it is re-evaluated every time its called. My biggest concern is that the
+      # test happens so fast that the test fails... I just don't know a better way to test it!
+      assert User.logged_in.where_values != User.logged_in.where_values, ERROR_MSG % '#logged_in'
+      
       assert_equal 0, User.logged_in.count
       User.first.update_attribute(:last_request_at, Time.now)
       assert_equal 1, User.logged_in.count
     end
     
     def test_named_scope_logged_out
+      # Testing that the scope returned differs, because the time it was called should be 
+      # slightly different. This is an attempt to make sure the scope is lambda wrapped 
+      # so that it is re-evaluated every time its called. My biggest concern is that the
+      # test happens so fast that the test fails... I just don't know a better way to test it!
+      assert User.logged_in.where_values != User.logged_out.where_values, ERROR_MSG % '#logged_out'
+      
       assert_equal 2, User.logged_out.count
       User.first.update_attribute(:last_request_at, Time.now)
       assert_equal 1, User.logged_out.count


### PR DESCRIPTION
I finally narrowed down an issue I was having where users still showed up as `#logged_in` after the `logged_in_timeout` had passed. I did notice there is already an issue opened addressing this (https://github.com/binarylogic/authlogic/issues/258). Here is a pull request with tests that should fix the problem... I wasn't completely satisfied with how I implemented the test, so if you have a better suggestion, I'd love to hear :)

Also, apparently I was "_really_ unlucky" because I couldn't get `#test_random_tokens_are_indeed_random` to pass. It is saying that `SecureRandom` is not defined.. I played around with it for awhile, but I couldn't figure out why I couldn't get to `SecureRandom`. Anyway, maybe you can point me in the right direction there.

Thanks!
