### PR TITLE
Fixed code documentation typos

### DIFF
--- a/lib/authlogic/acts_as_authentic/persistence_token.rb
+++ b/lib/authlogic/acts_as_authentic/persistence_token.rb
@@ -1,7 +1,7 @@
 module Authlogic
   module ActsAsAuthentic
     # Maintains the persistence token, the token responsible for persisting sessions. This token
-    # gets stores in the session and the cookie.
+    # gets stored in the session and the cookie.
     module PersistenceToken
       def self.included(klass)
         klass.class_eval do

--- a/lib/authlogic/session/persistence.rb
+++ b/lib/authlogic/session/persistence.rb
@@ -46,7 +46,7 @@ module Authlogic
       
       module InstanceMethods
         # Let's you know if the session is being persisted or not, meaning the user does not have to explicitly log in
-        # in order to be logged in. If the session has no associated record, it will try to find a record and persis
+        # in order to be logged in. If the session has no associated record, it will try to find a record and persist
         # the session. This is the method that the class level method find uses to ultimately persist the session.
         def persisting?
           return true if !record.nil?


### PR DESCRIPTION
I found and corrected a couple typos in the code comments.
