### PR TITLE
Prevent email regex from matching newlines

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -13,7 +13,7 @@ module Authlogic
       email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
       domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
       domain_tld_regex  = '(?:[A-Z]{2,4}|museum|travel)'
-      @email_regex = /^#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}$/i
+      @email_regex = /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
     end
     
     # A simple regular expression that only allows for letters, numbers, spaces, and .-_@. Just a standard login / username

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -85,6 +85,10 @@ module ActsAsAuthenticTest
       u.email = "dakota.d'ux@gmail.com"
       u.valid?
       assert u.errors[:email].size == 0
+      
+      u.email = "<script>alert(123);</script>\nnobody@example.com"
+      assert !u.valid?
+      assert u.errors[:email].size > 0
     end
 
     def test_validates_uniqueness_of_email_field


### PR DESCRIPTION
The email regex should be using \A and \z instead of ^ and $.

Explanation at http://guides.rubyonrails.org/security.html#regular-expressions

This should close #95.
