### PR TITLE
fixes issues #260

### DIFF
--- a/lib/authlogic/session/foundation.rb
+++ b/lib/authlogic/session/foundation.rb
@@ -19,7 +19,7 @@ module Authlogic
           def rw_config(key, value, default_value = nil, read_value = nil)
             if value == read_value
               return acts_as_authentic_config[key] if acts_as_authentic_config.include?(key)
-              rw_config(key, default_value)
+              rw_config(key, default_value) unless default_value.nil?
             else
               config = acts_as_authentic_config.clone
               config[key] = value


### PR DESCRIPTION
Trying to rw_config a nil value where the default_value is also nil ( for instance, using omniauth and not using "login" or "password" credentials) will give raise a Stack Too Deep exception.

Patch simply checks if the default_value is nil, and if so leaves the key empty in config (which will return nil anyway.)
