### PR TITLE
Require `ActionController` in Rails adapter

### DIFF
--- a/lib/authlogic/controller_adapters/rails_adapter.rb
+++ b/lib/authlogic/controller_adapters/rails_adapter.rb
@@ -1,3 +1,5 @@
+require 'action_controller'
+
 module Authlogic
   module ControllerAdapters
     # Adapts authlogic to work with rails. The point is to close the gap between what authlogic expects and what the rails controller object


### PR DESCRIPTION
Fixes #275
