### PR TITLE
Enforce CamelCase for class_name in session.rb generator

### DIFF
--- a/generators/session/templates/session.rb
+++ b/generators/session/templates/session.rb
@@ -1,2 +1,2 @@
-class <%= class_name %> < Authlogic::Session::Base
+class <%= class_name.camelcase %> < Authlogic::Session::Base
 end

--- a/lib/generators/authlogic/templates/session.rb
+++ b/lib/generators/authlogic/templates/session.rb
@@ -1,2 +1,2 @@
-class <%= session_class_name %> < Authlogic::Session::Base
+class <%= session_class_name.camelcase %> < Authlogic::Session::Base
 end


### PR DESCRIPTION
If user calls the 'authlogic:session' generator with `user_session`, it should generate the `UserSession` model.
