### PR TITLE
fixes validations to load i18n messages at runtime

### DIFF
--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -65,7 +65,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.email, :message => lambda {I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_email_field_options(value = nil)
-          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")})
+          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => Proc.new{I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}})
         end
         alias_method :validates_format_of_email_field_options=, :validates_format_of_email_field_options
 

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -62,7 +62,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.login, :message => lambda {I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_login_field_options(value = nil)
-          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")})
+          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => Proc.new{I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}})
         end
         alias_method :validates_format_of_login_field_options=, :validates_format_of_login_field_options
 

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -33,9 +33,16 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_format_of_email_field_options_config
-      default = {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}
-      assert_equal default, User.validates_format_of_email_field_options
-      assert_equal default, Employee.validates_format_of_email_field_options
+      email_invalid_msg = I18n.t('error_messages.email_invalid', :default => "should look like an email address.")
+      default = {:with => Authlogic::Regex.email, :message => email_invalid_msg}
+
+      user_options = User.validates_format_of_email_field_options
+      assert_equal default[:with], user_options[:with]
+      assert_equal email_invalid_msg, user_options[:message].call
+
+      employee_options = Employee.validates_format_of_email_field_options
+      assert_equal default[:with], employee_options[:with]
+      assert_equal email_invalid_msg, employee_options[:message].call
 
       User.validates_format_of_email_field_options = {:yes => "no"}
       assert_equal({:yes => "no"}, User.validates_format_of_email_field_options)

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -33,9 +33,16 @@ module ActsAsAuthenticTest
     end
     
     def test_validates_format_of_login_field_options_config
-      default = {:with => /\A\w[\w\.+\-_@ ]+$/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}
-      assert_equal default, User.validates_format_of_login_field_options
-      assert_equal default, Employee.validates_format_of_login_field_options
+      login_invalid_msg = I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")
+      default = {:with => /\A\w[\w\.+\-_@ ]+$/, :message => login_invalid_msg}
+
+      user_options = User.validates_format_of_login_field_options
+      assert_equal default[:with], user_options[:with]
+      assert_equal login_invalid_msg, user_options[:message].call
+
+      employee_options = Employee.validates_format_of_login_field_options
+      assert_equal default[:with], employee_options[:with]
+      assert_equal login_invalid_msg, employee_options[:message].call
       
       User.validates_format_of_login_field_options = {:yes => "no"}
       assert_equal({:yes => "no"}, User.validates_format_of_login_field_options)


### PR DESCRIPTION
This fixes the invalid email/login messages.  Perhaps this closes off #29.
