### PR TITLE
Consistent error messages

### DIFF
--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -62,10 +62,10 @@ module Authlogic
         # merge options into it. Checkout the convenience function merge_validates_format_of_email_field_options to merge
         # options.</b>
         #
-        # * <tt>Default:</tt> {:with => Authlogic::Regex.email, :message => lambda {I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}}
+        # * <tt>Default:</tt> {:with => Authlogic::Regex.email, :message => lambda {I18n.t('error_messages.email_invalid', :default => "should look like an email address")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_email_field_options(value = nil)
-          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")})
+          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address")})
         end
         alias_method :validates_format_of_email_field_options=, :validates_format_of_email_field_options
 

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -62,7 +62,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.login, :message => lambda {I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_login_field_options(value = nil)
-          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")})
+          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please")})
         end
         alias_method :validates_format_of_login_field_options=, :validates_format_of_login_field_options
 

--- a/lib/authlogic/i18n.rb
+++ b/lib/authlogic/i18n.rb
@@ -31,15 +31,15 @@ module Authlogic
   #     error_messages:
   #       login_blank: can not be blank
   #       login_not_found: is not valid
-  #       login_invalid: should use only letters, numbers, spaces, and .-_@ please.
-  #       consecutive_failed_logins_limit_exceeded: Consecutive failed logins limit exceeded, account is disabled.
-  #       email_invalid: should look like an email address.
+  #       login_invalid: should use only letters, numbers, spaces, and .-_@ please
+  #       consecutive_failed_logins_limit_exceeded: Consecutive failed logins limit exceeded, account has been temporarily disabled (the word "temporarily" does not appear if Authlogic::Session::BruteForceProtection::Config#failed_login_ban_for is passed 0)
+  #       email_invalid: should look like an email address
   #       password_blank: can not be blank
   #       password_invalid: is not valid
   #       not_active: Your account is not active
   #       not_confirmed: Your account is not confirmed
   #       not_approved: Your account is not approved
-  #       no_authentication_details: You did not provide any details for authentication.
+  #       no_authentication_details: You did not provide any details for authentication
   #       general_credentials_error: Login/Password combination is not valid
   #     models:
   #       user_session: UserSession (or whatever name you are using)

--- a/lib/authlogic/session/brute_force_protection.rb
+++ b/lib/authlogic/session/brute_force_protection.rb
@@ -79,7 +79,7 @@ module Authlogic
             errors.clear # Clear all other error messages, as they are irrelevant at this point and can only provide additional information that is not needed
             errors.add(:base, I18n.t(
               'error_messages.consecutive_failed_logins_limit_exceeded', 
-              :default => "Consecutive failed logins limit exceeded, account has been" + (failed_login_ban_for == 0 ? "" : " temporarily") + " disabled."
+              :default => "Consecutive failed logins limit exceeded, account has been" + (failed_login_ban_for == 0 ? "" : " temporarily") + " disabled"
             ))
           end
           

--- a/lib/authlogic/session/validation.rb
+++ b/lib/authlogic/session/validation.rb
@@ -75,7 +75,7 @@ module Authlogic
       
       private
         def ensure_authentication_attempted
-          errors.add(:base, I18n.t('error_messages.no_authentication_details', :default => "You did not provide any details for authentication.")) if errors.empty? && attempted_record.nil?
+          errors.add(:base, I18n.t('error_messages.no_authentication_details', :default => "You did not provide any details for authentication")) if errors.empty? && attempted_record.nil?
         end
     end
   end

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -33,7 +33,7 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_format_of_email_field_options_config
-      default = {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}
+      default = {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address")}
       assert_equal default, User.validates_format_of_email_field_options
       assert_equal default, Employee.validates_format_of_email_field_options
 

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -33,7 +33,7 @@ module ActsAsAuthenticTest
     end
     
     def test_validates_format_of_login_field_options_config
-      default = {:with => /\A\w[\w\.+\-_@ ]+$/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}
+      default = {:with => /\A\w[\w\.+\-_@ ]+$/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please")}
       assert_equal default, User.validates_format_of_login_field_options
       assert_equal default, Employee.validates_format_of_login_field_options
       


### PR DESCRIPTION
Noticed that some error messages in Authlogic have a full stop while others don't. Considering that most don't, and that Rails error messages also don't include a full stop at the end of the sentence, I thought removing the full stop would probably be the best thing to do.

Updated documentation relating to these error messages. In particular the documentation for the consecutive_failed_logins_limit_exceeded error message key did not seem to fully reflect the actual code.
