### PR TITLE
Fix I18n bug for email field and login field

### DIFF
--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -65,7 +65,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.email, :message => lambda {I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_email_field_options(value = nil)
-          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")})
+          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => lambda {I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}})
         end
         alias_method :validates_format_of_email_field_options=, :validates_format_of_email_field_options
 

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -62,7 +62,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.login, :message => lambda {I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_login_field_options(value = nil)
-          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")})
+          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => lambda {I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}})
         end
         alias_method :validates_format_of_login_field_options=, :validates_format_of_login_field_options
 


### PR DESCRIPTION
I18n-message should be inside a lambda, as documentation above it states. Otherwise it will be always the
default I18n language and will not be evaluation on request time. 
