### PR TITLE
SHA crypto providers: Compare hex values as integers

### DIFF
--- a/lib/authlogic/crypto_providers/sha1.rb
+++ b/lib/authlogic/crypto_providers/sha1.rb
@@ -27,7 +27,7 @@ module Authlogic
         
         # Does the crypted password match the tokens? Uses the same tokens that were used to encrypt.
         def matches?(crypted, *tokens)
-          encrypt(*tokens) == crypted
+          encrypt(*tokens).to_i(16) == crypted.to_i(16)
         end
       end
     end

--- a/lib/authlogic/crypto_providers/sha256.rb
+++ b/lib/authlogic/crypto_providers/sha256.rb
@@ -42,7 +42,7 @@ module Authlogic
         
         # Does the crypted password match the tokens? Uses the same tokens that were used to encrypt.
         def matches?(crypted, *tokens)
-          encrypt(*tokens) == crypted
+          encrypt(*tokens).to_i(16) == crypted.to_i(16)
         end
       end
     end

--- a/lib/authlogic/crypto_providers/sha512.rb
+++ b/lib/authlogic/crypto_providers/sha512.rb
@@ -42,7 +42,7 @@ module Authlogic
         
         # Does the crypted password match the tokens? Uses the same tokens that were used to encrypt.
         def matches?(crypted, *tokens)
-          encrypt(*tokens) == crypted
+          encrypt(*tokens).to_i(16) == crypted.to_i(16)
         end
       end
     end

--- a/test/crypto_provider_test/sha256_test.rb
+++ b/test/crypto_provider_test/sha256_test.rb
@@ -10,5 +10,28 @@ module CryptoProviderTest
       hash = Authlogic::CryptoProviders::Sha256.encrypt("mypass")
       assert Authlogic::CryptoProviders::Sha256.matches?(hash, "mypass")
     end
+    
+    def test_hex_case_mismatch_example_failure
+      digest = Authlogic::CryptoProviders::Sha256.encrypt("mypass")
+      
+      # Third parties sometimes generate the digest in uppercase
+
+      # For example Java generates hex in upper case (which is the
+      # problem I had)
+
+      # EA71C25A7A602246B4C39824B855678894A96F43BB9B71319C39700A1E045222
+
+      # instead of 
+
+      # ea71c25a7a602246b4c39824b855678894a96f43bb9b71319c39700a1e045222
+
+      # While validating passwords string match fails - note the
+      # not_equal
+      assert_not_equal digest, digest.upcase
+
+      # While Integer match won't
+      assert_equal digest.to_i(16), digest.upcase.to_i(16)
+    end
+
   end
 end


### PR DESCRIPTION
The SHA1, SHA256 and SHA512 crypto providers are using string comparison to verify if a password matches.

```encrypt(*tokens) == crypted```

Which works fine if authlogic is used to generate and match the crypted_password.

However, I recently faced a solution where another system had to create and verify users and passwords. All was well till we realised that that other system was generating hex string with upper case characters. Like "AB10" instead of "ab10".

I think the crypto providers that generate hex should compare them using integer comparison. All we have to do it to_i(16) on both sides of the comparison to get it going.

The pull requests does just that. No changes needed for tests, as the tests are passing strings, which would be the case from the database, and we just convert the hex strings to integers and compare them.