### PR TITLE
Integrate request_store to help with Threading issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     authlogic (3.3.0)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
+      request_store (~> 1.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -37,6 +38,7 @@ GEM
     minitest (4.7.5)
     multi_json (1.8.4)
     rake (10.1.1)
+    request_store (1.0.5)
     scrypt (1.2.0)
       ffi-compiler (>= 0.0.2)
       rake

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 3.2'
   s.add_dependency 'activesupport', '>= 3.2'
+  s.add_dependency 'request_store', '~>1.0.5'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'bcrypt-ruby'
   s.add_development_dependency 'scrypt'

--- a/lib/authlogic/session/activation.rb
+++ b/lib/authlogic/session/activation.rb
@@ -1,3 +1,5 @@
+require 'request_store'
+
 module Authlogic
   module Session
     # Activating Authlogic requires that you pass it an Authlogic::ControllerAdapters::AbstractAdapter object, or a class that extends it.
@@ -32,12 +34,12 @@ module Authlogic
         #
         # Lastly, this is thread safe.
         def controller=(value)
-          Thread.current[:authlogic_controller] = value
+          RequestStore.store[:authlogic_controller] = value
         end
         
         # The current controller object
         def controller
-          Thread.current[:authlogic_controller]
+          RequestStore.store[:authlogic_controller]
         end
       end
       

--- a/lib/authlogic/session/scopes.rb
+++ b/lib/authlogic/session/scopes.rb
@@ -1,3 +1,5 @@
+require 'request_store'
+
 module Authlogic
   module Session
     # Authentication can be scoped, and it's easy, you just need to define how you want to scope everything. This should help you:
@@ -17,7 +19,7 @@ module Authlogic
       module ClassMethods
         # The current scope set, should be used in the block passed to with_scope.
         def scope
-          Thread.current[:authlogic_scope]
+          RequestStore.store[:authlogic_scope]
         end
 
         # What with_scopes focuses on is scoping the query when finding the object and the name of the cookie / session. It works very similar to
@@ -68,7 +70,7 @@ module Authlogic
 
         private
           def scope=(value)
-            Thread.current[:authlogic_scope] = value
+            RequestStore.store[:authlogic_scope] = value
           end
       end
 


### PR DESCRIPTION
Hey there! I ran into issues using `Thread.current` while working with Draper, and apparently Authlogic has them too. So I wrote a gem to handle it, and I figured you may want to use it too. Here's the Draper discussion: https://github.com/drapergem/draper/issues/390

Fixes #335.
## The Issue

If you use `Thread.current` to store state, and you use one of those fancy threaded servers like Puma or Thin, then what's in `Thread.current` doesn't get cleared per-request like it would if you were using Webrick or whatever. This causes subtle bugs.
## The Fix

Basically, I wrote a gem that gives you 'request local' storage. It quacks like a `Hash`, just like `Thread.current`, but a middleware ensures that you get a clean slate every request.

I ran your tests on 1.9.3 and they were passing, but the gem works with [basically every modern Ruby ever (and some not-so-modern ones)](https://travis-ci.org/steveklabnik/request_store/builds/3701085), so no issues there.

Thanks! :heart: :heart: :heart:
