### PR TITLE
Fix session persistence sql vulnerabilities 

### DIFF
--- a/lib/authlogic/session/session.rb
+++ b/lib/authlogic/session/session.rb
@@ -35,8 +35,8 @@ module Authlogic
               # Allow finding by persistence token, because when records are created the session is maintained in a before_save, when there is no id.
               # This is done for performance reasons and to save on queries.
               record = record_id.nil? ?
-                search_for_record("find_by_persistence_token", persistence_token) :
-                search_for_record("find_by_#{klass.primary_key}", record_id)
+                search_for_record("find_by_persistence_token", persistence_token.to_s) :
+                search_for_record("find_by_#{klass.primary_key}", record_id.to_s)
               self.unauthorized_record = record if record && record.persistence_token == persistence_token
               valid?
             else

--- a/test/session_test/session_test.rb
+++ b/test/session_test/session_test.rb
@@ -20,6 +20,24 @@ module SessionTest
         assert_equal ben, session.record
         assert_equal ben.persistence_token, controller.session["user_credentials"]
       end
+
+      def test_persist_persist_by_session_with_session_fixation_attack
+        ben = users(:ben)
+        controller.session["user_credentials"] = 'neo'
+        controller.session["user_credentials_id"] = {:select => " *,'neo' AS persistence_token FROM users WHERE id = #{ben.id} limit 1 -- "}
+        @user_session = UserSession.find
+        assert @user_session.blank?
+      end
+
+      def test_persist_persist_by_session_with_sql_injection_attack
+        ben = users(:ben)
+        controller.session["user_credentials"] = {:select => "ABRA CADABRA"}
+        controller.session["user_credentials_id"] = nil
+        assert_nothing_raised do
+          @user_session = UserSession.find
+        end
+        assert @user_session.blank?
+      end
       
       def test_persist_persist_by_session_with_token_only
         ben = users(:ben)


### PR DESCRIPTION
# PROBLEM
- Rails session cookies are marshalled ruby Hashes.
- Authlogic stores a record's `id` and `persistence_token` in the rails session cookie. 
- Authlogic uses Rails' `find_by_*` methods when looking up `id` and `persistence_token`.
- The `find_by_*` methods accept option hashes, such as `:select => "..."`.

This leaves `persist_by_session` open to sql attacks (such as logging in as any user), if a malicious user can write their own rails session cookie (**if they have the rails secret_token**). 

Although authlogic verifies a user's identity with `persistence_token` stored in the database, this can currently be surpassed using this vulnerability, rendering `persistence_token` useless.
# SOLUTION

Use `to_s` on the session credentials when looking up a user.
