### PR TITLE
add Authlogic::Session::Cookies#sign_cookies config option

### DIFF
--- a/lib/authlogic/test_case/mock_cookie_jar.rb
+++ b/lib/authlogic/test_case/mock_cookie_jar.rb
@@ -9,6 +9,31 @@ module Authlogic
       def delete(key, options = {})
         super(key)
       end
+
+      def signed
+        @signed ||= MockSignedCookieJar.new(self)
+      end
+    end
+
+    class MockSignedCookieJar < MockCookieJar
+      attr_reader :parent_jar # helper for testing
+
+      def initialize(parent_jar)
+        @parent_jar = parent_jar
+      end
+
+      def [](val)
+        if signed_message = @parent_jar[val]
+          payload, signature = signed_message.split('--')
+          raise "Invalid signature" unless Digest::SHA1.hexdigest(payload) == signature
+          payload
+        end
+      end
+
+      def []=(key, options)
+        options[:value] = "#{options[:value]}--#{Digest::SHA1.hexdigest options[:value]}"
+        @parent_jar[key] = options
+      end
     end
   end
 end


### PR DESCRIPTION
### WHAT

Add a config option to `cookies` to use Rails-style signed cookies for the `remember_me` cookie (disabled by default).
### WHY

Just as an extra precaution to take, if desired. 
### GOTCHA

When this switch is toggled, already-existing cookies in the wild will be invalidated.

Thoughts?
