### PR TITLE
Fix for error message translation (issue 332)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ PLATFORMS
 DEPENDENCIES
   authlogic!
   bcrypt-ruby
+  i18n
   rake
   scrypt
   sqlite3

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'scrypt'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'timecop'
+  s.add_development_dependency 'i18n'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -65,7 +65,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.email, :message => Proc.new {I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_email_field_options(value = nil)
-          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => Proc.new{I18n.t('error_messages.email_invalid', :default => "should look like an email address.")})
+          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => Proc.new{I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}})
         end
         alias_method :validates_format_of_email_field_options=, :validates_format_of_email_field_options
 

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -33,14 +33,51 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_format_of_email_field_options_config
-      default = {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}
-      assert_equal default, User.validates_format_of_email_field_options
-      assert_equal default, Employee.validates_format_of_email_field_options
+      default = {:with => Authlogic::Regex.email, :message => Proc.new{I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}}
+      dmessage = default.delete(:message).call
+
+      options = User.validates_format_of_email_field_options
+      message = options.delete(:message)
+      assert message.kind_of?(Proc)     
+      assert_equal dmessage, message.call
+      assert_equal default, options
+
+      options = Employee.validates_format_of_email_field_options
+      message = options.delete(:message)
+      assert message.kind_of?(Proc)     
+      assert_equal dmessage, message.call
+      assert_equal default, options
+
 
       User.validates_format_of_email_field_options = {:yes => "no"}
       assert_equal({:yes => "no"}, User.validates_format_of_email_field_options)
       User.validates_format_of_email_field_options default
       assert_equal default, User.validates_format_of_email_field_options
+    end
+
+    def test_deferred_error_message_translation
+
+      # ensure we successfully loaded the test locale
+      assert I18n.available_locales.include?(:lol), "Test locale failed to load"
+
+      original_locale = I18n.locale
+      I18n.locale = 'lol'
+      message = I18n.t("authlogic.error_messages.email_invalid")
+
+      begin
+        cat = User.new
+        cat.email = 'meow'
+        cat.valid?
+
+        # filter duplicate error messages
+        error = cat.errors[:email]
+        error = error.first if error.is_a?(Array)
+
+        assert_equal message, error
+
+      ensure
+        I18n.locale = original_locale
+      end
     end
 
     def test_validates_uniqueness_of_email_field_options_config

--- a/test/i18n/lol.yml
+++ b/test/i18n/lol.yml
@@ -1,0 +1,4 @@
+lol:
+  authlogic:
+    error_messages:
+      email_invalid: LOL email should be valid.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,9 @@ require "rubygems"
 require "active_record"
 require "active_record/fixtures"
 require "timecop"
+require "i18n"
+
+I18n.load_path << File.dirname(__FILE__) + '/i18n/lol.yml'
 
 #ActiveRecord::Schema.verbose = false
 ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")


### PR DESCRIPTION
Defer the call to I18n.t for 'error_messages.email_invalid' because the I18n.locale may change between class initialization time and run time. This is definitely true in my app which handles users from multiple locales simultaneously, changing the locale for each request.

Update: OK this now includes a proper test. 
