### PR TITLE
Rails 4: Replaced call to deprecated `with_scope'

### DIFF
--- a/lib/authlogic/session/scopes.rb
+++ b/lib/authlogic/session/scopes.rb
@@ -91,7 +91,18 @@ module Authlogic
           end
 
           def search_for_record(*args)
-            klass.send(:with_scope, :find => (scope[:find_options] || {})) do
+            where_content = nil
+            current_scope = nil
+
+            if scope.has_key?(:find_options)
+              if scope[:find_options].is_a?(Hash) and scope[:find_options].has_key?(:conditions)
+                where_content = scope[:find_options][:conditions]
+              elsif scope[:find_options].is_a?(ActiveRecord::Relation)
+                current_scope = scope[:find_options]
+              end
+            end
+
+            klass.send(:where, where_content).merge(current_scope).send(:scoping) do
               klass.send(*args)
             end
           end


### PR DESCRIPTION
As you can see in the official gem rails/activerecord-deprecated_finders, with_scope has been deprecated.

```
ActiveRecord::Base#with_scope and #with_exclusive_scope are deprecated.
Please use ActiveRecord::Relation#scoping instead. (You can use #merge to merge multiple scopes together.)
```

This update fixes that problem, by using 'where', 'merge' and 'scoping'.
