### PR TITLE
Replace callback terminator strings by lambdas.

### DIFF
--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -63,8 +63,8 @@ module Authlogic
       
       def self.included(base) #:nodoc:
         base.send :include, ActiveSupport::Callbacks
-        base.define_callbacks *METHODS + [{:terminator => 'result == false'}]
-        base.define_callbacks *['persist', {:terminator => 'result == true'}]
+        base.define_callbacks *METHODS + [{:terminator => lambda {|result| result == false}}]
+        base.define_callbacks *['persist', {:terminator => lambda {|result| result == true}}]
 
         # If Rails 3, support the new callback syntax
         if base.singleton_class.method_defined?(:set_callback)


### PR DESCRIPTION
Rails 4 master deprecates string callback terminators (as part of a major rewrite of the callback framework in ActiveSupport) and prints a warning requesting to replace them by lambdas. This is what this pull request does.

However, previous Rails versions (including the already existing 4-0-stable and 4-0-0 branches) only support strings but not lambdas, so there is no solution that works on all current Rails versions.

IMO there are two options:
- Insert a check to test for Rails version > 4.0 (not >=).
- Create a new branch to support Rails 4 (as has been done for Rails 2 vs Rails 3), but require a Rails version later than 4.0.0.

Both variants assume the changes in ActiveSupport will make it into the next minor release, e.g. 4.0.1. It might be a good idea to ask the Rails team to backport support for lambdas to 4-0-0 and 4-0-stable, though I'm not sure how likely this is to happen. The deprecation was introduced in rails/rails@ba552764344bc0a3c25b8576ec11f127ceaa16da.
