### PR TITLE
Fixed destroying cookies on sinatra

### DIFF
--- a/lib/authlogic/controller_adapters/sinatra_adapter.rb
+++ b/lib/authlogic/controller_adapters/sinatra_adapter.rb
@@ -11,7 +11,7 @@ module Authlogic
         end
 
         def delete(key, options = {})
-          @request.cookies.delete(key)
+          @response.delete_cookie(key, options)
         end
 
         def []=(key, options)


### PR DESCRIPTION
current_user_session.destroy is not working now because header of response does not contain destroying of user session
