### PR TITLE
Update e-mail regex to be compatible with new gTLDs

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -12,11 +12,11 @@ module Authlogic
       @email_regex ||= begin
         email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
         domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
-        domain_tld_regex  = '(?:[A-Z]{2,4}|museum|travel)'
+        domain_tld_regex  = '(?:[A-Z]{2,4}|museum|travel|онлайн)'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
       end
     end
-    
+
     # A simple regular expression that only allows for letters, numbers, spaces, and .-_@. Just a standard login / username
     # regular expression.
     def self.login


### PR DESCRIPTION
ICANN recently approved four new gTLDs including one that is >4 characters and fails to pass the e-mail regex. This patch adds the онлайн gTLD for when these TLDs come online.

http://newgtlds.icann.org/en/announcements-and-media/announcement-15jul13-en
