### PR TITLE
Remember Me fails to parse cookie in Ruby 2.0

### DIFF
--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -170,7 +170,7 @@ module Authlogic
           end
           
           def save_cookie
-            remember_me_until_value = "::#{remember_me_until}" if remember_me?
+            remember_me_until_value = "::#{remember_me_until.iso8601}" if remember_me?
             controller.cookies[cookie_key] = {
               :value => "#{record.persistence_token}::#{record.send(record.class.primary_key)}#{remember_me_until_value}",
               :expires => remember_me_until,


### PR DESCRIPTION
I didn't find anything about this googling so it is possible (likely?) that I'm missing something, but the remember_me feature fails for me in Ruby 2.0.

The root problem is that the expiration is stored in the cookie by to_s'ing the expire time, and then read back with Time.parse. But in the USA locales, Time.parse can't properly parse a M/D/Y date format, so once the cookie is set, all page loads begin failing.

I have patched my local copy to work around this by storing the time in the cookie in a more standardized/non-locale-dependent format.

Input welcome.
