### PR TITLE
Pass the session to the controller's `last_request_update_allowed?` method

### DIFF
--- a/lib/authlogic/controller_adapters/abstract_adapter.rb
+++ b/lib/authlogic/controller_adapters/abstract_adapter.rb
@@ -54,8 +54,13 @@ module Authlogic
         controller.respond_to?(:last_request_update_allowed?, true)
       end
 
-      def last_request_update_allowed?
-        controller.send(:last_request_update_allowed?)
+      def last_request_update_allowed?(session)
+        case controller.method(:last_request_update_allowed?).arity
+        when 0
+          controller.send(:last_request_update_allowed?)
+        when 1
+          controller.send(:last_request_update_allowed?, session)
+        end
       end
 
       private

--- a/lib/authlogic/session/magic_columns.rb
+++ b/lib/authlogic/session/magic_columns.rb
@@ -71,14 +71,14 @@ module Authlogic
           # session before it times out. Obviously you would want to ignore this request, because then the user would never time out.
           # So you can do something like this in your controller:
           #
-          #   def last_request_update_allowed?
+          #   def last_request_update_allowed?(session)
           #     action_name =! "update_session_time_left"
           #   end
           #
           # You can do whatever you want with that method.
           def set_last_request_at? # :doc:
             return false if !record || !klass.column_names.include?("last_request_at")
-            return controller.last_request_update_allowed? if controller.responds_to_last_request_update_allowed?
+            return controller.last_request_update_allowed?(self) if controller.responds_to_last_request_update_allowed?
             record.last_request_at.blank? || last_request_at_threshold.to_i.seconds.ago >= record.last_request_at
           end
         


### PR DESCRIPTION
This patch passes the calling-session through to your controller's `last_request_update_allowed?` method to enable a developer to not update `last_request_at` for a given session, if there are multiple existing sessions.

I use it like this:

```
class ApplicationController
  ...
  def last_request_update_allowed?(session)
    sesson.id != UserSession::SECURE
  end
end
```

(The slightly odd choice of base for this branch is because I need this to work on my Rails 3.0 app too.)
