### PR TITLE
Fixed deprecated (by ActiveSupport 4.1.0) string terminators

### DIFF
--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -63,8 +63,13 @@ module Authlogic
       
       def self.included(base) #:nodoc:
         base.send :include, ActiveSupport::Callbacks
-        base.define_callbacks *METHODS + [{:terminator => 'result == false'}]
-        base.define_callbacks *['persist', {:terminator => 'result == true'}]
+        if ActiveSupport::VERSION::STRING >= '4.1'
+          base.define_callbacks *METHODS + [{:terminator => ->(target, result){ result == false } }]
+          base.define_callbacks *['persist', {:terminator => ->(target, result){ result == false } }]
+        else
+          base.define_callbacks *METHODS + [{:terminator => 'result == false'}]
+          base.define_callbacks *['persist', {:terminator => 'result == true'}]
+        end
 
         # If Rails 3, support the new callback syntax
         if base.singleton_class.method_defined?(:set_callback)


### PR DESCRIPTION
Deprecated here: https://github.com/rails/rails/blob/b894b7b90a6aced0e78ab84a45bf1c75c871bb2d/activesupport/lib/active_support/callbacks.rb#L722
