### PR TITLE
fix deprecation warning by removing #scoped call

### DIFF
--- a/lib/authlogic/authenticates_many/base.rb
+++ b/lib/authlogic/authenticates_many/base.rb
@@ -42,7 +42,7 @@ module Authlogic
         options[:relationship_name] ||= options[:session_class].klass_name.underscore.pluralize
         class_eval <<-"end_eval", __FILE__, __LINE__
           def #{name}
-            find_options = #{options[:find_options].inspect} || #{options[:relationship_name]}.scoped
+            find_options = #{options[:find_options].inspect} || #{options[:relationship_name]}
             @#{name} ||= Authlogic::AuthenticatesMany::Association.new(#{options[:session_class]}, find_options, #{options[:scope_cookies] ? "self.class.model_name.underscore + '_' + self.send(self.class.primary_key).to_s" : "nil"})
           end
         end_eval


### PR DESCRIPTION
DEPRECATION WARNING: Model.scoped is deprecated. Please use Model.all instead.
  (called from user_sessions at .../authlogic/lib/authlogic/authenticates_many/base.rb:44
