### PR TITLE
Fix bug in persist callback for Rails 4.1

### DIFF
--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -65,7 +65,7 @@ module Authlogic
         base.send :include, ActiveSupport::Callbacks
         if ActiveSupport::VERSION::STRING >= '4.1'
           base.define_callbacks *METHODS + [{:terminator => ->(target, result){ result == false } }]
-          base.define_callbacks *['persist', {:terminator => ->(target, result){ result == false } }]
+          base.define_callbacks *['persist', {:terminator => ->(target, result){ result == true } }]
         else
           base.define_callbacks *METHODS + [{:terminator => 'result == false'}]
           base.define_callbacks *['persist', {:terminator => 'result == true'}]


### PR DESCRIPTION
I noticed a couple of days back when using the fork that introduced this change, that my code did not run anymore, my spec were failing, testing use rails server failed. I tested just now with master and have the same problem. Looking at the new code I saw that where persist previously had a `'result==true'` (look at line 71), it now has `result==false`. Changing this resolves the problem.
