### PR TITLE
Error message should be a proc

### DIFF
--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -65,7 +65,7 @@ module Authlogic
         # * <tt>Default:</tt> {:with => Authlogic::Regex.email, :message => lambda {I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_email_field_options(value = nil)
-          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => I18n.t('error_messages.email_invalid', :default => "should look like an email address.")})
+          rw_config(:validates_format_of_email_field_options, value, {:with => Authlogic::Regex.email, :message => Proc.new{I18n.t('error_messages.email_invalid', :default => "should look like an email address.")}})
         end
         alias_method :validates_format_of_email_field_options=, :validates_format_of_email_field_options
 


### PR DESCRIPTION
To fix the first pair of errors mentioned in #393, the error message returned by the validators was supposed to be a proc, but it wasn't. So it returned the translation as it was when the model was setup, not with the locate of the moment the validation occurs.
