### PR TITLE
Update email regex to not care about case so that it can work with Judge...

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -11,9 +11,9 @@ module Authlogic
     # for regular expressions.
     def self.email
       @email_regex ||= begin
-        email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
-        domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
-        domain_tld_regex  = '(?:[A-Z]{2,4}|museum|travel|онлайн)'
+        email_name_regex  = '[a-zA-Z0-9_\.%\+\-\']+'
+        domain_head_regex = '(?:[a-zA-Z0-9\-]+\.)+'
+        domain_tld_regex  = '(?:[a-zA-Z]{2,4}|museum|travel|онлайн)'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
       end
     end


### PR DESCRIPTION
... validations

Judge creates validations on the client side using the Ruby regex. The email validation fails on the client although it passes on the server because it is case sensitive. 
