### PR TITLE
Fix: Autoload CryptoProvider classes

### DIFF
--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -9,13 +9,7 @@ path = File.dirname(__FILE__) + "/authlogic/"
 
  "controller_adapters/abstract_adapter",
 
- "crypto_providers/md5",
- "crypto_providers/sha1",
- "crypto_providers/sha256",
- "crypto_providers/sha512",
- "crypto_providers/bcrypt",
- "crypto_providers/aes256",
- "crypto_providers/scrypt",
+ "crypto_providers",
 
  "authenticates_many/base",
  "authenticates_many/association",

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -149,7 +149,11 @@ module Authlogic
         # * <tt>Default:</tt> CryptoProviders::SCrypt
         # * <tt>Accepts:</tt> Class
         def crypto_provider(value = nil)
-          rw_config(:crypto_provider, value, CryptoProviders::SCrypt)
+          if value.nil? and !acts_as_authentic_config.include?(:crypto_provider)
+            rw_config(:crypto_provider, CryptoProviders::SCrypt)
+          else
+            rw_config(:crypto_provider, value)
+          end
         end
         alias_method :crypto_provider=, :crypto_provider
 

--- a/lib/authlogic/acts_as_authentic/restful_authentication.rb
+++ b/lib/authlogic/acts_as_authentic/restful_authentication.rb
@@ -8,7 +8,7 @@ module Authlogic
           include InstanceMethods
         end
       end
-      
+
       module Config
         # Switching an existing app to Authlogic from restful_authentication? No problem, just set this true and your users won't know
         # anything changed. From your database perspective nothing will change at all. Authlogic will continue to encrypt passwords
@@ -23,18 +23,18 @@ module Authlogic
           r
         end
         alias_method :act_like_restful_authentication=, :act_like_restful_authentication
-        
+
         # This works just like act_like_restful_authentication except that it will start transitioning your users to the algorithm you
         # specify with the crypto provider option. The next time they log in it will resave their password with the new algorithm
         # and any new record will use the new algorithm as well. Make sure to update your users table if you are using the default
-        # migration since it will set crypted_password and salt columns to a maximum width of 40 characters which is not enough. 
+        # migration since it will set crypted_password and salt columns to a maximum width of 40 characters which is not enough.
         def transition_from_restful_authentication(value = nil)
           r = rw_config(:transition_from_restful_authentication, value, false)
           set_restful_authentication_config if value
           r
         end
         alias_method :transition_from_restful_authentication=, :transition_from_restful_authentication
-        
+
         private
           def set_restful_authentication_config
             crypto_provider_key = act_like_restful_authentication ? :crypto_provider : :transition_from_crypto_providers
@@ -45,13 +45,13 @@ module Authlogic
             end
           end
       end
-      
+
       module InstanceMethods
         private
           def act_like_restful_authentication?
             self.class.act_like_restful_authentication == true
           end
-          
+
           def transition_from_restful_authentication?
             self.class.transition_from_restful_authentication == true
           end

--- a/lib/authlogic/crypto_providers.rb
+++ b/lib/authlogic/crypto_providers.rb
@@ -1,0 +1,11 @@
+module Authlogic
+  module CryptoProviders
+    autoload :MD5,    "authlogic/crypto_providers/md5"
+    autoload :Sha1,   "authlogic/crypto_providers/sha1"
+    autoload :Sha256, "authlogic/crypto_providers/sha256"
+    autoload :Sha512, "authlogic/crypto_providers/sha512"
+    autoload :BCrypt, "authlogic/crypto_providers/bcrypt"
+    autoload :AES256, "authlogic/crypto_providers/aes256"
+    autoload :SCrypt, "authlogic/crypto_providers/scrypt"
+  end
+end


### PR DESCRIPTION
In a recent commit (https://github.com/binarylogic/authlogic/commit/c2eae1ce2e30a8c613313cfe167cb46b0fff0287) I removed some old require code for bcrypt/scrypt. 

This ends up throwing the `LoadError` in your app if you don't have those two gems in your Gemfile, but we still don't necessarily need the gems to run Authlogic. 

This change autoloads each `CryptoProvider` when necessary rather than requiring all of them when loading Authlogic.
