### PR TITLE
Update email regexp to allow top-level domains up to 13 characters long

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -5,15 +5,15 @@ module Authlogic
   #
   #   validates_format_of :my_email_field, :with => Authlogic::Regex.email
   module Regex
-    # A general email regular expression. It allows top level domains (TLD) to be from 2 - 4 in length, any
-    # TLD longer than that must be manually specified. The decisions behind this regular expression were made
-    # by reading this website: http://www.regular-expressions.info/email.html, which is an excellent resource
-    # for regular expressions.
+    # A general email regular expression. It allows top level domains (TLD) to be from 2 - 13 in length.
+    # The decisions behind this regular expression were made by analyzing the list of top-level domains
+    # maintained by IANA and by reading this website: http://www.regular-expressions.info/email.html,
+    # which is an excellent resource for regular expressions.
     def self.email
       @email_regex ||= begin
         email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
         domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
-        domain_tld_regex  = '(?:[A-Z]{2,4}|museum|travel|онлайн)'
+        domain_tld_regex  = '(?:[A-Z]{2,13})'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
       end
     end


### PR DESCRIPTION
We recently started getting complaints from users with email TLDs longer than 4 characters: *.email, *.photography, etc. By doing a quick analysis of [IANA’s list](http://data.iana.org/TLD/tlds-alpha-by-domain.txt) it becomes apparent that it is no longer possible to validate TLDs longer than 4 characters against a predefined whitelist. Here is a simple Ruby snippet to reinforce this argument:

``` ruby
open('http://data.iana.org/TLD/tlds-alpha-by-domain.txt').
    each_line.
    lazy.
    reject { |l| l.start_with?('XN--') || l.start_with?('#') }.
    map(&:strip).
    reduce({}) { |m, l| m[l.length] = m[l.length].to_i + 1; m }.
    sort_by { |k, v| k }.
    each { |(d, l)| puts "#{d}\t#{l}" }
# length count
#2 249
#3 34
#4 47
#5 35
#6 36
#7 28
#8 22
#9 9
#10  9
#11  5
#12  1
#13  1
```

Also the [page](http://www.regular-expressions.info/email.html) used to build the existing regexp clearly states: "Regexes Don’t Send Email" to make a point that no regexp is going to protect you from users submitting non-existing emails.

Given all this I believe it should be safe to extend this limit. Please let me know what you think.
