### PR TITLE
Adding bcrypt and scrypt as dependency

### DIFF
--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 3.2'
   s.add_dependency 'activesupport', '>= 3.2'
   s.add_dependency 'request_store', '~> 1.0'
-  s.add_development_dependency 'bcrypt-ruby', '~> 3.1'
-  s.add_development_dependency 'scrypt', '~> 1.2'
+  s.add_dependency 'bcrypt-ruby', '~> 3.1'
+  s.add_dependency 'scrypt', '~> 1.2'
+
   s.add_development_dependency 'timecop', '~> 0.7'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Adding bcrypt and scrypt as direct (not development) dependency. Otherwise it produce an error:

```
/var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/activesupport-3.2.18/lib/active_support/dependencies.rb:251:in `require': cannot load such file -- scrypt (LoadError)
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/activesupport-3.2.18/lib/active_support/dependencies.rb:251:in `block in require'
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/activesupport-3.2.18/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1gems/activesupport-3.2.18/lib/active_support/dependencies.rb:251:in `require'
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/authlogic-3.4.2/lib/authlogic/crypto_providers/scrypt.rb:1:in `<top (required)>'
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/authlogic-3.4.2/lib/authlogic/acts_as_authentic/password.rb:153:in `crypto_provider'
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/authlogic-3.4.2/lib/authlogic/acts_as_authentic/password.rb:349:in `crypto_provider'
    from /var/lib/jenkins/.rvm/gems/ruby-2.1.1/gems/authlogic-3.4.2/lib/authlogic/acts_as_authentic/password.rb:244:in `password='
```

See also: 
- http://stackoverflow.com/questions/22894172/rails-server-and-console-fails-to-start-due-to-authlogic-for-ruby-2-0-and-rails
- http://stackoverflow.com/questions/23031902/rails-4-1-0-and-authlogic-bcrypt-issue
