### PR TITLE
Update the way that callbacks are added to the model

### DIFF
--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -15,7 +15,7 @@ module Authlogic
     #   persist
     #   after_persisting
     #   [save record if record.changed?]
-    #   
+    #
     #   before_validation
     #   before_validation_on_create
     #   before_validation_on_update
@@ -24,7 +24,7 @@ module Authlogic
     #   after_validation_on_create
     #   after_validation
     #   [save record if record.changed?]
-    #   
+    #
     #   before_save
     #   before_create
     #   before_update
@@ -32,7 +32,7 @@ module Authlogic
     #   after_create
     #   after_save
     #   [save record if record.changed?]
-    #   
+    #
     #   before_destroy
     #   [save record if record.changed?]
     #   destroy
@@ -60,7 +60,7 @@ module Authlogic
         "before_save", "before_create", "before_update", "after_update", "after_create", "after_save",
         "before_destroy", "after_destroy"
       ]
-      
+
       def self.included(base) #:nodoc:
         base.send :include, ActiveSupport::Callbacks
         if ActiveSupport::VERSION::STRING >= '4.1'
@@ -75,14 +75,14 @@ module Authlogic
         if base.singleton_class.method_defined?(:set_callback)
           METHODS.each do |method|
             base.class_eval <<-"end_eval", __FILE__, __LINE__
-              def self.#{method}(*methods, &block)
-                set_callback :#{method}, *methods, &block
-              end
+              def self.#{method}(*methods, &block)                              # def self.before_persisting(*methods, block)
+                set_callback :#{method}, *methods, &block                       #   set_callback :before_persisting, *methods, &block
+              end                                                               # end
             end_eval
           end
         end
       end
-      
+
       private
         METHODS.each do |method|
           class_eval <<-"end_eval", __FILE__, __LINE__
@@ -91,7 +91,7 @@ module Authlogic
             end
           end_eval
         end
-        
+
         def save_record(alternate_record = nil)
           r = alternate_record || record
           r.save_without_session_maintenance(:validate => false) if r && r.changed? && !r.readonly?

--- a/test/acts_as_authentic_test/callbacks_test.rb
+++ b/test/acts_as_authentic_test/callbacks_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class TestUserSession < Authlogic::Session::Base; end
+
+class TestUser < ActiveRecord::Base
+  self.table_name = "users"
+  acts_as_authentic
+  attr_accessor :counter
+  def initialize(*args)
+    @counter = 0
+    super
+  end
+end
+
+
+module ActsAsAuthenticTest
+  class CallbacksTest < ActiveSupport::TestCase
+    def setup
+      TestUser.reset_callbacks(:password_set)
+      TestUser.reset_callbacks(:password_verification)
+
+      @u = TestUser.create(:password => "good password", :password_confirmation => "good password", :login => "awesome", :email => "awesome@awesome.com").reload
+    end
+
+    def test_password_setter_runs_callbacks
+      TestUser.before_password_set { |s| s.counter += 1 }
+      TestUser.after_password_set { |s| s.counter += 1 }
+
+      assert_equal 0, @u.counter
+      @u.password = "blah"
+      assert_equal 2, @u.counter
+    end
+
+
+    def test_valid_password_with_bad_password_runs_callbacks
+      TestUser.before_password_verification { |s| s.counter += 1 }
+      TestUser.after_password_verification { |s| s.counter += 1 }
+
+      assert_equal 0, @u.counter
+      assert !@u.valid_password?("bad password")
+      assert_equal 1, @u.counter
+    end
+
+    def test_valid_password_with_good_password_runs_callbacks
+      TestUser.before_password_verification { |s| s.counter += 1 }
+      TestUser.after_password_verification { |s| s.counter += 1 }
+
+      assert_equal 0, @u.counter
+      assert @u.valid_password?("good password")
+      assert_equal 2, @u.counter
+    end
+  end
+end

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -5,33 +5,33 @@ module ActsAsAuthenticTest
     def test_crypted_password_field_config
       assert_equal :crypted_password, User.crypted_password_field
       assert_equal :crypted_password, Employee.crypted_password_field
-      
+
       User.crypted_password_field = :nope
       assert_equal :nope, User.crypted_password_field
       User.crypted_password_field :crypted_password
       assert_equal :crypted_password, User.crypted_password_field
     end
-    
+
     def test_password_salt_field_config
       assert_equal :password_salt, User.password_salt_field
       assert_equal :password_salt, Employee.password_salt_field
-      
+
       User.password_salt_field = :nope
       assert_equal :nope, User.password_salt_field
       User.password_salt_field :password_salt
       assert_equal :password_salt, User.password_salt_field
     end
-    
+
     def test_ignore_blank_passwords_config
       assert User.ignore_blank_passwords
       assert Employee.ignore_blank_passwords
-      
+
       User.ignore_blank_passwords = false
       assert !User.ignore_blank_passwords
       User.ignore_blank_passwords true
       assert User.ignore_blank_passwords
     end
-    
+
     def test_check_passwords_against_database
       assert User.check_passwords_against_database
       User.check_passwords_against_database = false
@@ -39,76 +39,76 @@ module ActsAsAuthenticTest
       User.check_passwords_against_database true
       assert User.check_passwords_against_database
     end
-    
+
     def test_validate_password_field_config
       assert User.validate_password_field
       assert Employee.validate_password_field
-      
+
       User.validate_password_field = false
       assert !User.validate_password_field
       User.validate_password_field true
       assert User.validate_password_field
     end
-    
+
     def test_validates_length_of_password_field_options_config
       default = {:minimum => 4, :if => :require_password?}
       assert_equal default, User.validates_length_of_password_field_options
       assert_equal default, Employee.validates_length_of_password_field_options
-      
+
       User.validates_length_of_password_field_options = {:yes => "no"}
       assert_equal({:yes => "no"}, User.validates_length_of_password_field_options)
       User.validates_length_of_password_field_options default
       assert_equal default, User.validates_length_of_password_field_options
     end
-    
+
     def test_validates_confirmation_of_password_field_options_config
       default = {:if => :require_password?}
       assert_equal default, User.validates_confirmation_of_password_field_options
       assert_equal default, Employee.validates_confirmation_of_password_field_options
-      
+
       User.validates_confirmation_of_password_field_options = {:yes => "no"}
       assert_equal({:yes => "no"}, User.validates_confirmation_of_password_field_options)
       User.validates_confirmation_of_password_field_options default
       assert_equal default, User.validates_confirmation_of_password_field_options
     end
-    
+
     def test_validates_length_of_password_confirmation_field_options_config
       default = {:minimum => 4, :if => :require_password?}
       assert_equal default, User.validates_length_of_password_confirmation_field_options
       assert_equal default, Employee.validates_length_of_password_confirmation_field_options
-      
+
       User.validates_length_of_password_confirmation_field_options = {:yes => "no"}
       assert_equal({:yes => "no"}, User.validates_length_of_password_confirmation_field_options)
       User.validates_length_of_password_confirmation_field_options default
       assert_equal default, User.validates_length_of_password_confirmation_field_options
     end
-    
+
     def test_crypto_provider_config
       assert_equal Authlogic::CryptoProviders::SCrypt, User.crypto_provider
       assert_equal Authlogic::CryptoProviders::AES256, Employee.crypto_provider
-      
+
       User.crypto_provider = Authlogic::CryptoProviders::BCrypt
       assert_equal Authlogic::CryptoProviders::BCrypt, User.crypto_provider
       User.crypto_provider Authlogic::CryptoProviders::Sha512
       assert_equal Authlogic::CryptoProviders::Sha512, User.crypto_provider
     end
-    
+
     def test_transition_from_crypto_providers_config
       assert_equal [], User.transition_from_crypto_providers
       assert_equal [], Employee.transition_from_crypto_providers
-      
+
       User.transition_from_crypto_providers = [Authlogic::CryptoProviders::BCrypt]
       assert_equal [Authlogic::CryptoProviders::BCrypt], User.transition_from_crypto_providers
       User.transition_from_crypto_providers []
       assert_equal [], User.transition_from_crypto_providers
     end
-    
+
     def test_validates_length_of_password
       u = User.new
       u.password_confirmation = "test2"
       assert !u.valid?
       assert u.errors[:password].size > 0
-      
+
       u.password = "test"
       assert !u.valid?
 
@@ -118,7 +118,7 @@ module ActsAsAuthenticTest
         assert u.errors[:password_confirmation].size == 0
       end
     end
-    
+
     def test_validates_confirmation_of_password
       u = User.new
       u.password = "test"
@@ -134,30 +134,30 @@ module ActsAsAuthenticTest
       assert !u.valid?
       assert u.errors[:password].size == 0
     end
-    
+
     def test_validates_length_of_password_confirmation
       u = User.new
-      
+
       u.password = "test"
       u.password_confirmation = ""
       assert !u.valid?
       assert u.errors[:password_confirmation].size > 0
-      
+
       u.password_confirmation = "test"
       assert !u.valid?
       assert u.errors[:password_confirmation].size == 0
-      
+
       ben = users(:ben)
       assert ben.valid?
-      
+
       ben.password = "newpass"
       assert !ben.valid?
       assert ben.errors[:password_confirmation].size > 0
-      
+
       ben.password_confirmation = "newpass"
       assert ben.valid?
     end
-    
+
     def test_password
       u = User.new
       old_password_salt = u.password_salt
@@ -166,60 +166,60 @@ module ActsAsAuthenticTest
       assert_not_equal old_password_salt, u.password_salt
       assert_not_equal old_crypted_password, u.crypted_password
     end
-    
+
     def test_transitioning_password
       ben = users(:ben)
       transition_password_to(Authlogic::CryptoProviders::BCrypt, ben)
       transition_password_to(Authlogic::CryptoProviders::Sha1, ben, [Authlogic::CryptoProviders::Sha512, Authlogic::CryptoProviders::BCrypt])
       transition_password_to(Authlogic::CryptoProviders::Sha512, ben, [Authlogic::CryptoProviders::Sha1, Authlogic::CryptoProviders::BCrypt])
     end
-    
+
     def test_checks_password_against_database
       ben = users(:aaron)
       ben.password = "new pass"
       assert !ben.valid_password?("new pass")
       assert ben.valid_password?("aaronrocks")
     end
-    
+
     def test_checks_password_against_database_and_always_fails_on_new_records
       user = User.new
       user.password = "new pass"
       assert !user.valid_password?("new pass")
     end
-    
+
     def test_checks_password_against_object
       ben = users(:ben)
       ben.password = "new pass"
       assert ben.valid_password?("new pass", false)
       assert !ben.valid_password?("benrocks", false)
     end
-    
+
     def test_reset_password
       ben = users(:ben)
       old_crypted_password = ben.crypted_password
       old_password_salt = ben.password_salt
-      
+
       # soft reset
       ben.reset_password
       assert_not_equal old_crypted_password, ben.crypted_password
       assert_not_equal old_password_salt, ben.password_salt
-      
+
       # make sure it didn't go into the db
       ben.reload
       assert_equal old_crypted_password, ben.crypted_password
       assert_equal old_password_salt, ben.password_salt
-      
+
       # hard reset
       assert ben.reset_password!
       assert_not_equal old_crypted_password, ben.crypted_password
       assert_not_equal old_password_salt, ben.password_salt
-      
+
       # make sure it did go into the db
       ben.reload
       assert_not_equal old_crypted_password, ben.crypted_password
       assert_not_equal old_password_salt, ben.password_salt
     end
-    
+
     private
       def transition_password_to(crypto_provider, records, from_crypto_providers = Authlogic::CryptoProviders::Sha512)
         records = [records] unless records.is_a?(Array)
@@ -233,7 +233,7 @@ module ActsAsAuthenticTest
           assert record.valid_password?(password_for(record))
           assert_not_equal old_hash.to_s, record.crypted_password.to_s
           assert_not_equal old_persistence_token.to_s, record.persistence_token.to_s
-          
+
           old_hash = record.crypted_password
           old_persistence_token = record.persistence_token
           assert record.valid_password?(password_for(record))


### PR DESCRIPTION
### WHAT

Define the callbacks for models a little more sanely, using `ActiveModel::Callbacks#define_model_callbacks`.
### WHY

The way callbacks are implemented is a little outdated/confusing. 

For instance, `Model.before_password_set` is currently a helper method that we generate. 

When invoked, it calls `set_callback :before_password_set, :my_custom_callback`.

This actually sets `my_custom_callback` as a before filter to run before `before_password_set`. So we have callback chains on methods that are named like callbacks.

Instead, we could define `password_set` to have a callback chain (`after` and `before`), and use `define_model_callbacks` to generate those class helper methods for us (eg the methods that actually set the callbacks on `password_set`).
### NEXT

We should also refactor `Authlogic::Session::Callbacks`, but that one is a little tougher.
