### PR TITLE
Reference gem ‘bcrypt’ instead of its old name ‘bcrypt-ruby’

### DIFF
--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 3.2'
   s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'scrypt', '~> 1.2'
-  s.add_development_dependency 'bcrypt-ruby', '~> 3.1'
+  s.add_development_dependency 'bcrypt', '~> 3.1'
   s.add_development_dependency 'timecop', '~> 0.7'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/authlogic/crypto_providers/bcrypt.rb
+++ b/lib/authlogic/crypto_providers/bcrypt.rb
@@ -34,7 +34,7 @@ module Authlogic
     #
     # Decided BCrypt is for you? Just install the bcrypt gem:
     #
-    #   gem install bcrypt-ruby
+    #   gem install bcrypt
     #
     # Tell acts_as_authentic to use it:
     #


### PR DESCRIPTION
`bundle install` resulted in this message:

```
Post-install message from bcrypt-ruby:

#######################################################

The bcrypt-ruby gem has changed its name to just bcrypt.  Instead of
installing `bcrypt-ruby`, you should install `bcrypt`.  Please update your
dependencies accordingly.

#######################################################
```

As far as I can tell, the two gems are identical except `bcrypt` has a slightly newer version, so there should be no compatibility problems from this switch.
