### PR TITLE
Fix domain head regex for email validation

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -12,7 +12,7 @@ module Authlogic
     def self.email
       @email_regex ||= begin
         email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
-        domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
+        domain_head_regex = '(?:[A-Z0-9]+([.-][A-Z0-9]+)*\.)'
         domain_tld_regex  = '(?:[A-Z]{2,13})'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
       end

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -117,6 +117,22 @@ module ActsAsAuthenticTest
       u.valid?
       assert u.errors[:email].size == 0
 
+      u.email = "dakota@my-.com"
+      u.valid?
+      assert u.errors[:email].size > 0
+
+      u.email = "dakota@my-domain.com"
+      u.valid?
+      assert u.errors[:email].size == 0
+
+      u.email = "dakota@sub.my-.com"
+      u.valid?
+      assert u.errors[:email].size > 0
+
+      u.email = "dakota@sub.my-domain.com"
+      u.valid?
+      assert u.errors[:email].size == 0
+
       u.email = "<script>alert(123);</script>\nnobody@example.com"
       assert !u.valid?
       assert u.errors[:email].size > 0


### PR DESCRIPTION
**What**
A small fix to improve the email validation regex.

**Why**
The current regex allows `me@you-.com`. However domain and subdomain names may not start, or end with `-`.