### PR TITLE
Extract rw_config into module, and clean it up a little.

### DIFF
--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -6,6 +6,7 @@ path = File.dirname(__FILE__) + "/authlogic/"
  "i18n",
  "random",
  "regex",
+ "config",
 
  "controller_adapters/abstract_adapter",
 

--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -4,9 +4,9 @@ module Authlogic
     module Base
       def self.included(klass)
         klass.class_eval do
-          class_attribute :acts_as_authentic_modules, :acts_as_authentic_config
+          class_attribute :acts_as_authentic_modules
           self.acts_as_authentic_modules ||= []
-          self.acts_as_authentic_config  ||= {}
+          extend Authlogic::Config
           extend Config
         end
       end
@@ -73,17 +73,6 @@ module Authlogic
               true
             rescue Exception
               false
-            end
-          end
-
-          def rw_config(key, value, default_value = nil, read_value = nil)
-            if value == read_value
-              acts_as_authentic_config.include?(key) ? acts_as_authentic_config[key] : default_value
-            else
-              config = acts_as_authentic_config.clone
-              config[key] = value
-              self.acts_as_authentic_config = config
-              value
             end
           end
 

--- a/lib/authlogic/config.rb
+++ b/lib/authlogic/config.rb
@@ -1,0 +1,23 @@
+#encoding: utf-8
+module Authlogic
+  module Config
+    def self.extended(klass)
+      klass.class_eval do
+        class_attribute :acts_as_authentic_config
+        self.acts_as_authentic_config ||= {}
+      end
+    end
+
+    private
+      # This is a one-liner method to write a config setting, read the config
+      # setting, and also set a default value for the setting.
+      def rw_config(key, value, default_value = nil)
+        if value.nil?
+          acts_as_authentic_config.include?(key) ? acts_as_authentic_config[key] : default_value
+        else
+          self.acts_as_authentic_config = acts_as_authentic_config.merge(key => value)
+          value
+        end
+      end
+  end
+end

--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -43,8 +43,8 @@ module Authlogic
         #
         # * <tt>Default:</tt> 3.months
         # * <tt>Accepts:</tt> Integer, length of time in seconds, such as 60 or 3.months
-        def remember_me_for(value = :_read)
-          rw_config(:remember_me_for, value, 3.months, :_read)
+        def remember_me_for(value = nil)
+          rw_config(:remember_me_for, value, 3.months)
         end
         alias_method :remember_me_for=, :remember_me_for
 
@@ -206,7 +206,7 @@ module Authlogic
               controller.cookies[cookie_key] = generate_cookie_for_saving
             end
           end
-          
+
           def generate_cookie_for_saving
             remember_me_until_value = "::#{remember_me_until.iso8601}" if remember_me?
             {

--- a/lib/authlogic/session/foundation.rb
+++ b/lib/authlogic/session/foundation.rb
@@ -6,34 +6,16 @@ module Authlogic
     module Foundation
       def self.included(klass)
         klass.class_eval do
-          class_attribute :acts_as_authentic_config
-          self.acts_as_authentic_config  ||= {}
-          
-          extend ClassMethods
+          extend Authlogic::Config
           include InstanceMethods
         end
       end
-      
-      module ClassMethods
-        private
-          def rw_config(key, value, default_value = nil, read_value = nil)
-            if value == read_value
-              return acts_as_authentic_config[key] if acts_as_authentic_config.include?(key)
-              rw_config(key, default_value) unless default_value.nil?
-            else
-              config = acts_as_authentic_config.clone
-              config[key] = value
-              self.acts_as_authentic_config = config
-              value
-            end
-          end
-      end
-      
+
       module InstanceMethods
         def initialize(*args)
           self.credentials = args
         end
-        
+
         # The credentials you passed to create your session. See credentials= for more info.
         def credentials
           []
@@ -54,11 +36,11 @@ module Authlogic
         #   session.credentials = [my_user_object, true, :my_id]
         def credentials=(values)
         end
-        
+
         def inspect
           "#<#{self.class.name}: #{credentials.blank? ? "no credentials provided" : credentials.inspect}>"
         end
-                
+
         private
           def build_key(last_part)
             last_part

--- a/test/acts_as_authentic_test/base_test.rb
+++ b/test/acts_as_authentic_test/base_test.rb
@@ -8,13 +8,13 @@ module ActsAsAuthenticTest
         end
       end
     end
-    
+
     def test_acts_as_authentic_with_old_config
       assert_raise(ArgumentError) do
         User.acts_as_authentic({})
       end
     end
-    
+
     def test_acts_as_authentic_with_no_table
       klass = Class.new(ActiveRecord::Base)
       assert_nothing_raised do

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class ConfigTest < ActiveSupport::TestCase
+  def setup
+    @klass = Class.new {
+      extend Authlogic::Config
+
+      def self.foobar(value = nil)
+        rw_config(:foobar_field, value, 'default_foobar')
+      end
+    }
+
+    @subklass = Class.new(@klass)
+  end
+
+  def test_config
+    assert_equal({}, @klass.acts_as_authentic_config)
+  end
+
+  def test_rw_config_read_with_default
+    assert 'default_foobar', @klass.foobar
+  end
+
+  def test_rw_config_write
+    assert_equal 'my_foobar', @klass.foobar('my_foobar')
+    assert_equal 'my_foobar', @klass.foobar
+
+    assert_equal 'my_new_foobar', @klass.foobar('my_new_foobar')
+    assert_equal 'my_new_foobar', @klass.foobar
+  end
+
+  def test_subclass_rw_config_write
+    assert_equal 'subklass_foobar', @subklass.foobar('subklass_foobar')
+    assert_equal 'default_foobar', @klass.foobar
+  end
+end

--- a/test/session_test/foundation_test.rb
+++ b/test/session_test/foundation_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+
+module SessionTest
+  class FoundationTest < ActiveSupport::TestCase
+  end
+end


### PR DESCRIPTION
### WHAT

Move `rw_config` into a module, and include that module in `Authlogic::ActsAsAuthentic::Base` and `Authlogic::Session::Foundation`. Tests included.
### WHY

Currently `rw_config` is defined in the 2 modules, but their implementation is slightly different. We should make this easier to understand and test it.
