### PR TITLE
Better test suite fix for config changes on test models

### DIFF
--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -38,13 +38,13 @@ module ActsAsAuthenticTest
 
       options = User.validates_format_of_email_field_options
       message = options.delete(:message)
-      assert message.kind_of?(Proc)     
+      assert message.kind_of?(Proc)
       assert_equal dmessage, message.call
       assert_equal default, options
 
       options = Employee.validates_format_of_email_field_options
       message = options.delete(:message)
-      assert message.kind_of?(Proc)     
+      assert message.kind_of?(Proc)
       assert_equal dmessage, message.call
       assert_equal default, options
 
@@ -56,15 +56,12 @@ module ActsAsAuthenticTest
     end
 
     def test_deferred_error_message_translation
-
       # ensure we successfully loaded the test locale
       assert I18n.available_locales.include?(:lol), "Test locale failed to load"
 
-      original_locale = I18n.locale
-      I18n.locale = 'lol'
-      message = I18n.t("authlogic.error_messages.email_invalid")
+      I18n.with_locale('lol') do
+        message = I18n.t("authlogic.error_messages.email_invalid")
 
-      begin
         cat = User.new
         cat.email = 'meow'
         cat.valid?
@@ -74,9 +71,6 @@ module ActsAsAuthenticTest
         error = error.first if error.is_a?(Array)
 
         assert_equal message, error
-
-      ensure
-        I18n.locale = original_locale
       end
     end
 
@@ -122,7 +116,7 @@ module ActsAsAuthenticTest
       u.email = "dakota.d'ux@gmail.com"
       u.valid?
       assert u.errors[:email].size == 0
-      
+
       u.email = "<script>alert(123);</script>\nnobody@example.com"
       assert !u.valid?
       assert u.errors[:email].size > 0

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -84,9 +84,6 @@ module ActsAsAuthenticTest
     end
 
     def test_crypto_provider_config
-      original_crypto_provider = User.crypto_provider
-      original_transition_from_crypto_providers = User.transition_from_crypto_providers
-
       assert_equal Authlogic::CryptoProviders::SCrypt, User.crypto_provider
       assert_equal Authlogic::CryptoProviders::AES256, Employee.crypto_provider
 
@@ -94,14 +91,9 @@ module ActsAsAuthenticTest
       assert_equal Authlogic::CryptoProviders::BCrypt, User.crypto_provider
       User.crypto_provider Authlogic::CryptoProviders::Sha512
       assert_equal Authlogic::CryptoProviders::Sha512, User.crypto_provider
-    ensure
-      User.crypto_provider = original_crypto_provider
-      User.transition_from_crypto_providers = original_transition_from_crypto_providers
     end
 
     def test_transition_from_crypto_providers_config
-      original_transition_from_crypto_providers = User.transition_from_crypto_providers
-
       assert_equal [Authlogic::CryptoProviders::Sha512], User.transition_from_crypto_providers
       assert_equal [], Employee.transition_from_crypto_providers
 
@@ -109,8 +101,6 @@ module ActsAsAuthenticTest
       assert_equal [Authlogic::CryptoProviders::BCrypt], User.transition_from_crypto_providers
       User.transition_from_crypto_providers []
       assert_equal [], User.transition_from_crypto_providers
-    ensure
-      User.transition_from_crypto_providers = original_transition_from_crypto_providers
     end
 
     def test_validates_length_of_password
@@ -171,17 +161,11 @@ module ActsAsAuthenticTest
     end
 
     def test_transitioning_password
-      original_crypto_provider = User.crypto_provider
-      original_transition_from_crypto_providers = User.transition_from_crypto_providers
-
       ben = users(:ben)
 
       transition_password_to(Authlogic::CryptoProviders::BCrypt, ben)
       transition_password_to(Authlogic::CryptoProviders::Sha1, ben, [Authlogic::CryptoProviders::Sha512, Authlogic::CryptoProviders::BCrypt])
       transition_password_to(Authlogic::CryptoProviders::Sha512, ben, [Authlogic::CryptoProviders::Sha1, Authlogic::CryptoProviders::BCrypt])
-    ensure
-      User.crypto_provider = original_crypto_provider
-      User.transition_from_crypto_providers = original_transition_from_crypto_providers
     end
 
     def test_checks_password_against_database

--- a/test/acts_as_authentic_test/restful_authentication_test.rb
+++ b/test/acts_as_authentic_test/restful_authentication_test.rb
@@ -3,9 +3,6 @@ require 'test_helper'
 module ActsAsAuthenticTest
   class RestfulAuthenticationTest < ActiveSupport::TestCase
     def test_act_like_restful_authentication_config
-      original_crypto_provider = User.crypto_provider
-      original_transition_from_crypto_providers = User.transition_from_crypto_providers
-
       assert !User.act_like_restful_authentication
       assert !Employee.act_like_restful_authentication
 
@@ -21,15 +18,9 @@ module ActsAsAuthenticTest
 
       User.crypto_provider = Authlogic::CryptoProviders::Sha512
       User.transition_from_crypto_providers = []
-    ensure
-      User.crypto_provider = original_crypto_provider
-      User.transition_from_crypto_providers = original_transition_from_crypto_providers
     end
 
     def test_transition_from_restful_authentication_config
-      original_crypto_provider = User.crypto_provider
-      original_transition_from_crypto_providers = User.transition_from_crypto_providers
-
       assert !User.transition_from_restful_authentication
       assert !Employee.transition_from_restful_authentication
 
@@ -41,9 +32,6 @@ module ActsAsAuthenticTest
 
       User.transition_from_restful_authentication false
       assert !User.transition_from_restful_authentication
-    ensure
-      User.crypto_provider = original_crypto_provider
-      User.transition_from_crypto_providers = original_transition_from_crypto_providers
     end
   end
 end

--- a/test/session_test/brute_force_protection_test.rb
+++ b/test/session_test/brute_force_protection_test.rb
@@ -4,27 +4,19 @@ module SessionTest
   module BruteForceProtectionTest
     class ConfigTest < ActiveSupport::TestCase
       def test_consecutive_failed_logins_limit
-        original_consecutive_failed_logins_limit = UserSession.consecutive_failed_logins_limit
-
         UserSession.consecutive_failed_logins_limit = 10
         assert_equal 10, UserSession.consecutive_failed_logins_limit
 
         UserSession.consecutive_failed_logins_limit 50
         assert_equal 50, UserSession.consecutive_failed_logins_limit
-      ensure
-        UserSession.consecutive_failed_logins_limit = original_consecutive_failed_logins_limit
       end
 
       def test_failed_login_ban_for
-        original_failed_login_ban_for = UserSession.failed_login_ban_for
-
         UserSession.failed_login_ban_for = 10
         assert_equal 10, UserSession.failed_login_ban_for
 
         UserSession.failed_login_ban_for 2.hours
         assert_equal 2.hours.to_i, UserSession.failed_login_ban_for
-      ensure
-        UserSession.failed_login_ban_for = original_failed_login_ban_for
       end
     end
 

--- a/test/session_test/http_auth_test.rb
+++ b/test/session_test/http_auth_test.rb
@@ -26,8 +26,6 @@ module SessionTest
 
         UserSession.http_basic_auth_realm = 'TestRealm'
         assert_equal 'TestRealm', UserSession.http_basic_auth_realm
-      ensure
-        UserSession.http_basic_auth_realm = original_http_basic_auth_realm
       end
     end
 


### PR DESCRIPTION
### WHAT

Introduce a better fix for resetting test model configs in the test suite:
- `setup`: remember the original test model configs
- `teardown`: ensure we reset the test model configs to their originals, after each test has run
### WHY

Failures surfaced in Rails 4.1 because some tests would change the test model configs but not reset them (until this temp fix: https://github.com/binarylogic/authlogic/pull/435). This is a better fix, which wraps all test methods with a remember/reset strategy.
