### PR TITLE
Fix conflict between last_request_at_update_allowed? and last_request_at_threshold

### DIFF
--- a/lib/authlogic/session/magic_columns.rb
+++ b/lib/authlogic/session/magic_columns.rb
@@ -83,7 +83,7 @@ module Authlogic
           # You can do whatever you want with that method.
           def set_last_request_at? # :doc:
             return false if !record || !klass.column_names.include?("last_request_at")
-            return false if controller.responds_to_last_request_update_allowed? and !controller.last_request_update_allowed?
+            return false if controller.responds_to_last_request_update_allowed? && !controller.last_request_update_allowed?
             record.last_request_at.blank? || last_request_at_threshold.to_i.seconds.ago >= record.last_request_at
           end
 

--- a/lib/authlogic/session/magic_columns.rb
+++ b/lib/authlogic/session/magic_columns.rb
@@ -83,7 +83,7 @@ module Authlogic
           # You can do whatever you want with that method.
           def set_last_request_at? # :doc:
             return false if !record || !klass.column_names.include?("last_request_at")
-            return controller.last_request_update_allowed? if controller.responds_to_last_request_update_allowed?
+            return false if controller.responds_to_last_request_update_allowed? and !controller.last_request_update_allowed?
             record.last_request_at.blank? || last_request_at_threshold.to_i.seconds.ago >= record.last_request_at
           end
 


### PR DESCRIPTION
Currently, if an application uses both `last_request_at_update_allowed?` and `last_request_at_threshold`, the former takes priority over the latter. If the controller returns true to `last_request_at_update_allowed?`, then `last_request_at` WILL be updated, even if it's within the threshold time period.

This patch updates this behavior so that `last_request_at` is not updated if `last_request_at_update_allowed?` is true OR if `last_request_at_threshold` has not been met.