### PR TITLE
Fix Rails 4 #with_scope deprecation-warning

### DIFF
--- a/lib/authlogic/session/scopes.rb
+++ b/lib/authlogic/session/scopes.rb
@@ -91,7 +91,12 @@ module Authlogic
           end
 
           def search_for_record(*args)
-            klass.send(:with_scope, :find => (scope[:find_options] || {})) do
+            session_scope = if scope[:find_options].is_a?(ActiveRecord::Relation)
+              scope[:find_options]
+            else
+              klass.send(:where, scope[:find_options] && scope[:find_options][:conditions] || {})
+            end
+            session_scope.scoping do
               klass.send(*args)
             end
           end


### PR DESCRIPTION
Authlogic 3.4.x seems to have problems with Rails 4.0 and Cucumber (see #445), but 3.3.0 gives deprecation warnings in Rails 4. So I'm backporting #369 to version 3.3.0 in order to get rid of the deprecations. (I'd actually like this to be merged onto [v3.3.0](https://github.com/binarylogic/authlogic/tree/v3.3.0) (711ccf0674b13487b8520e2be12588a47475b051), not master, but GitHub doesn't seem to let me specify a backport target on a pull request.)
