### PR TITLE
Allow ampersand in email per RFC 2822 3.2.4

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -11,7 +11,7 @@ module Authlogic
     # which is an excellent resource for regular expressions.
     def self.email
       @email_regex ||= begin
-        email_name_regex  = '[A-Z0-9_\.%\+\-\']+'
+        email_name_regex  = '[A-Z0-9_\.&%\+\-\']+'
         domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
         domain_tld_regex  = '(?:[A-Z]{2,13})'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -120,6 +120,10 @@ module ActsAsAuthenticTest
       u.email = "<script>alert(123);</script>\nnobody@example.com"
       assert !u.valid?
       assert u.errors[:email].size > 0
+
+      u.email = "a&b@c.com"
+      u.valid?
+      assert u.errors[:email].size == 0
     end
 
     def test_validates_uniqueness_of_email_field


### PR DESCRIPTION
Apparently ampersands are allowed in email addresses according to the RFC. This PR should allow for that.