### PR TITLE
Rails 4.2 support

### DIFF
--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -116,10 +116,15 @@ module Authlogic
             relation = if not sensitivity
               connection.case_insensitive_comparison(arel_table, field.to_s, columns_hash[field.to_s], value)
             else
-              value    = connection.case_sensitive_modifier(value) if value
+              if value
+                if Gem::Version.new(Rails.version) < Gem::Version.new('4.2')
+                  value = connection.case_sensitive_modifier(value)
+                else
+                  value = connection.case_sensitive_modifier(value, field.to_s)
+                end
+              end
               relation = arel_table[field.to_s].eq(value)
             end
-
             where(relation).first
           end
       end

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -116,12 +116,10 @@ module Authlogic
             relation = if not sensitivity
               connection.case_insensitive_comparison(arel_table, field.to_s, columns_hash[field.to_s], value)
             else
-              if value
-                if Gem::Version.new(Rails.version) < Gem::Version.new('4.2')
-                  value = connection.case_sensitive_modifier(value)
-                else
-                  value = connection.case_sensitive_modifier(value, field.to_s)
-                end
+              if Gem::Version.new(Rails.version) < Gem::Version.new('4.2')
+                value = connection.case_sensitive_modifier(value)
+              else
+                value = connection.case_sensitive_modifier(value, field.to_s)
               end
               relation = arel_table[field.to_s].eq(value)
             end


### PR DESCRIPTION
The case_sensitive_modifiier api has now changed and required 2 params in rails 4.2.
https://github.com/rails/rails/blob/03b304c88588737f55f58952cd6cbe356cd75a90/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L624