### PR TITLE
Update the way callbacks are used, with new syntax.

### DIFF
--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -15,7 +15,7 @@ module Authlogic
     #   persist
     #   after_persisting
     #   [save record if record.changed?]
-    #   
+    #
     #   before_validation
     #   before_validation_on_create
     #   before_validation_on_update
@@ -24,7 +24,7 @@ module Authlogic
     #   after_validation_on_create
     #   after_validation
     #   [save record if record.changed?]
-    #   
+    #
     #   before_save
     #   before_create
     #   before_update
@@ -32,7 +32,7 @@ module Authlogic
     #   after_create
     #   after_save
     #   [save record if record.changed?]
-    #   
+    #
     #   before_destroy
     #   [save record if record.changed?]
     #   destroy
@@ -60,7 +60,7 @@ module Authlogic
         "before_save", "before_create", "before_update", "after_update", "after_create", "after_save",
         "before_destroy", "after_destroy"
       ]
-      
+
       def self.included(base) #:nodoc:
         base.send :include, ActiveSupport::Callbacks
         if ActiveSupport::VERSION::STRING >= '4.1'
@@ -75,14 +75,14 @@ module Authlogic
         if base.singleton_class.method_defined?(:set_callback)
           METHODS.each do |method|
             base.class_eval <<-"end_eval", __FILE__, __LINE__
-              def self.#{method}(*methods, &block)
-                set_callback :#{method}, *methods, &block
-              end
+              def self.#{method}(*methods, &block)                              # def self.before_persisting(*methods, block)
+                set_callback :#{method}, *methods, &block                       #   set_callback :before_persisting, *methods, &block
+              end                                                               # end
             end_eval
           end
         end
       end
-      
+
       private
         METHODS.each do |method|
           class_eval <<-"end_eval", __FILE__, __LINE__
@@ -91,7 +91,7 @@ module Authlogic
             end
           end_eval
         end
-        
+
         def save_record(alternate_record = nil)
           r = alternate_record || record
           r.save_without_session_maintenance(:validate => false) if r && r.changed? && !r.readonly?

--- a/test/acts_as_authentic_test/callbacks_test.rb
+++ b/test/acts_as_authentic_test/callbacks_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class TestUserSession < Authlogic::Session::Base; end
+
+class TestUser < ActiveRecord::Base
+  self.table_name = "users"
+  acts_as_authentic
+  attr_accessor :counter
+  def initialize(*args)
+    @counter = 0
+    super
+  end
+end
+
+
+module ActsAsAuthenticTest
+  class CallbacksTest < ActiveSupport::TestCase
+    def setup
+      TestUser.reset_callbacks(:password_set)
+      TestUser.reset_callbacks(:password_verification)
+
+      @u = TestUser.create(:password => "good password", :password_confirmation => "good password", :login => "awesome", :email => "awesome@awesome.com").reload
+    end
+
+    def test_password_setter_runs_callbacks
+      TestUser.before_password_set { |s| s.counter += 1 }
+      TestUser.after_password_set { |s| s.counter += 1 }
+
+      assert_equal 0, @u.counter
+      @u.password = "blah"
+      assert_equal 2, @u.counter
+    end
+
+
+    def test_valid_password_with_bad_password_runs_callbacks
+      TestUser.before_password_verification { |s| s.counter += 1 }
+      TestUser.after_password_verification { |s| s.counter += 1 }
+
+      assert_equal 0, @u.counter
+      assert !@u.valid_password?("bad password")
+      assert_equal 1, @u.counter
+    end
+
+    def test_valid_password_with_good_password_runs_callbacks
+      TestUser.before_password_verification { |s| s.counter += 1 }
+      TestUser.after_password_verification { |s| s.counter += 1 }
+
+      assert_equal 0, @u.counter
+      assert @u.valid_password?("good password")
+      assert_equal 2, @u.counter
+    end
+  end
+end

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -109,6 +109,10 @@ module ActsAsAuthenticTest
 
       u.password = u.password_confirmation = "abc"
       assert !u.valid?
+      assert u.errors[:password].size > 0
+
+      u.password = "test"
+      assert !u.valid?
 
       assert u.errors[:password].include?("is too short (minimum is 4 characters)")
       assert u.errors[:password_confirmation].include?("is too short (minimum is 4 characters)")


### PR DESCRIPTION
Modernize the way callbacks are used in `Authlogic::ActsAsAuthentic::Password` by extending `ActiveModel::Callbacks`.

(still need to double-check the changes here)