### PR TITLE
Fixes login validation message to respect the current locale

### DIFF
--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -78,10 +78,10 @@ module Authlogic
             value,
             {
               :with => Authlogic::Regex.login,
-              :message => I18n.t(
+              :message => Proc.new { I18n.t(
                 'error_messages.login_invalid',
                 :default => "should use only letters, numbers, spaces, and .-_@+ please."
-              )
+              ) }
             }
           )
         end

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -78,10 +78,12 @@ module Authlogic
             value,
             {
               :with => Authlogic::Regex.login,
-              :message => Proc.new { I18n.t(
-                'error_messages.login_invalid',
-                :default => "should use only letters, numbers, spaces, and .-_@+ please."
-              ) }
+              :message => proc do
+                I18n.t(
+                  'error_messages.login_invalid',
+                  :default => "should use only letters, numbers, spaces, and .-_@+ please."
+                )
+              end
             }
           )
         end

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -101,18 +101,18 @@ module ActsAsAuthenticTest
           )
         end
       }
-      dmessage = default.delete(:message).call
+      default_message = default.delete(:message).call
 
       options = User.validates_format_of_email_field_options
       message = options.delete(:message)
       assert message.kind_of?(Proc)
-      assert_equal dmessage, message.call
+      assert_equal default_message, message.call
       assert_equal default, options
 
       options = Employee.validates_format_of_email_field_options
       message = options.delete(:message)
       assert message.kind_of?(Proc)
-      assert_equal dmessage, message.call
+      assert_equal default_message, message.call
       assert_equal default, options
 
       User.validates_format_of_email_field_options = { :yes => "no" }

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -94,7 +94,7 @@ module ActsAsAuthenticTest
     def test_validates_format_of_email_field_options_config
       default = {
         :with => Authlogic::Regex.email,
-        :message => Proc.new do
+        :message => proc do
           I18n.t(
             'error_messages.email_invalid',
             :default => "should look like an email address."
@@ -105,13 +105,13 @@ module ActsAsAuthenticTest
 
       options = User.validates_format_of_email_field_options
       message = options.delete(:message)
-      assert message.kind_of?(Proc)
+      assert message.is_a?(Proc)
       assert_equal default_message, message.call
       assert_equal default, options
 
       options = Employee.validates_format_of_email_field_options
       message = options.delete(:message)
-      assert message.kind_of?(Proc)
+      assert message.is_a?(Proc)
       assert_equal default_message, message.call
       assert_equal default, options
 

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -35,22 +35,24 @@ module ActsAsAuthenticTest
     def test_validates_format_of_login_field_options_config
       default = {
         :with => /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/,
-        :message => Proc.new { I18n.t(
-          'error_messages.login_invalid',
-          :default => "should use only letters, numbers, spaces, and .-_@+ please."
-        ) }
+        :message => proc do
+          I18n.t(
+            'error_messages.login_invalid',
+            :default => "should use only letters, numbers, spaces, and .-_@+ please."
+          )
+        end
       }
       default_message = default.delete(:message).call
 
       options = User.validates_format_of_login_field_options
       message = options.delete(:message)
-      assert message.kind_of?(Proc)
+      assert message.is_a?(Proc)
       assert_equal default_message, message.call
       assert_equal default, options
 
       options = Employee.validates_format_of_login_field_options
       message = options.delete(:message)
-      assert message.kind_of?(Proc)
+      assert message.is_a?(Proc)
       assert_equal default_message, message.call
       assert_equal default, options
 

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -35,13 +35,24 @@ module ActsAsAuthenticTest
     def test_validates_format_of_login_field_options_config
       default = {
         :with => /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/,
-        :message => I18n.t(
+        :message => Proc.new { I18n.t(
           'error_messages.login_invalid',
           :default => "should use only letters, numbers, spaces, and .-_@+ please."
-        )
+        ) }
       }
-      assert_equal default, User.validates_format_of_login_field_options
-      assert_equal default, Employee.validates_format_of_login_field_options
+      default_message = default.delete(:message).call
+
+      options = User.validates_format_of_login_field_options
+      message = options.delete(:message)
+      assert message.kind_of?(Proc)
+      assert_equal default_message, message.call
+      assert_equal default, options
+
+      options = Employee.validates_format_of_login_field_options
+      message = options.delete(:message)
+      assert message.kind_of?(Proc)
+      assert_equal default_message, message.call
+      assert_equal default, options
 
       User.validates_format_of_login_field_options = { :yes => "no" }
       assert_equal({ :yes => "no" }, User.validates_format_of_login_field_options)


### PR DESCRIPTION
Login validation message will be rendered using the locale set at the time the validation is run rather than the locale at the time the file is booted.