### PR TITLE
Fixes validation message for error_messages.login_invalid

### DIFF
--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -59,10 +59,10 @@ module Authlogic
         # merge options into it. Checkout the convenience function merge_validates_format_of_login_field_options to merge
         # options.</b>
         #
-        # * <tt>Default:</tt> {:with => Authlogic::Regex.login, :message => lambda {I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}}
+        # * <tt>Default:</tt> {:with => Authlogic::Regex.login, :message => lambda {I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")}}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_login_field_options(value = nil)
-          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")})
+          rw_config(:validates_format_of_login_field_options, value, {:with => Authlogic::Regex.login, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")})
         end
         alias_method :validates_format_of_login_field_options=, :validates_format_of_login_field_options
 

--- a/lib/authlogic/i18n.rb
+++ b/lib/authlogic/i18n.rb
@@ -31,7 +31,7 @@ module Authlogic
   #     error_messages:
   #       login_blank: can not be blank
   #       login_not_found: is not valid
-  #       login_invalid: should use only letters, numbers, spaces, and .-_@ please.
+  #       login_invalid: should use only letters, numbers, spaces, and .-_@+ please.
   #       consecutive_failed_logins_limit_exceeded: Consecutive failed logins limit exceeded, account is disabled.
   #       email_invalid: should look like an email address.
   #       email_invalid_international: should look like an international email address.

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -33,7 +33,7 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_format_of_login_field_options_config
-      default = {:with => /\A\w[\w\.+\-_@ ]+\z/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@ please.")}
+      default = {:with => /\A\w[\w\.+\-_@ ]+\z/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")}
       assert_equal default, User.validates_format_of_login_field_options
       assert_equal default, Employee.validates_format_of_login_field_options
 


### PR DESCRIPTION
`should use only letters, numbers, spaces, and .-_@ please.`  =>
`should use only letters, numbers, spaces, and .-_@+ please.`