### PR TITLE
Fixes regex for validate login

### DIFF
--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -41,7 +41,7 @@ module Authlogic
     # A simple regular expression that only allows for letters, numbers, spaces, and .-_@+. Just a standard login / username
     # regular expression.
     def self.login
-      /\A\w[\w\.+\-_@ ]+\z/
+      /\A[a-zA-Z0-9][a-zA-Z0-9\.+\-_@ ]+\z/
     end
   end
 end

--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -41,7 +41,7 @@ module Authlogic
     # A simple regular expression that only allows for letters, numbers, spaces, and .-_@+. Just a standard login / username
     # regular expression.
     def self.login
-      /\A[a-zA-Z0-9][a-zA-Z0-9\.+\-_@ ]+\z/
+      /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/
     end
   end
 end

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -34,7 +34,7 @@ module ActsAsAuthenticTest
 
     def test_validates_format_of_login_field_options_config
 
-      default = {:with => /\A[a-zA-Z0-9][a-zA-Z0-9\.+\-_@ ]+\z/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")}
+      default = {:with => /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")}
       assert_equal default, User.validates_format_of_login_field_options
       assert_equal default, Employee.validates_format_of_login_field_options
 
@@ -97,7 +97,7 @@ module ActsAsAuthenticTest
 
       u.login = "_underscore"
       assert !u.valid?
-      assert u.errors[:login].size > 0
+      assert u.errors[:login].size == 0
 
       u.login = "@atmark"
       assert !u.valid?

--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -33,7 +33,8 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_format_of_login_field_options_config
-      default = {:with => /\A\w[\w\.+\-_@ ]+\z/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")}
+
+      default = {:with => /\A[a-zA-Z0-9][a-zA-Z0-9\.+\-_@ ]+\z/, :message => I18n.t('error_messages.login_invalid', :default => "should use only letters, numbers, spaces, and .-_@+ please.")}
       assert_equal default, User.validates_format_of_login_field_options
       assert_equal default, Employee.validates_format_of_login_field_options
 
@@ -77,6 +78,34 @@ module ActsAsAuthenticTest
       u.login = "dakota.dux+1@gmail.com"
       assert !u.valid?
       assert u.errors[:login].size == 0
+
+      u.login = "marks .-_@+"
+      assert !u.valid?
+      assert u.errors[:login].size == 0
+
+      u.login = " space"
+      assert !u.valid?
+      assert u.errors[:login].size > 0
+
+      u.login = ".dot"
+      assert !u.valid?
+      assert u.errors[:login].size > 0
+
+      u.login = "-hyphen"
+      assert !u.valid?
+      assert u.errors[:login].size > 0
+
+      u.login = "_underscore"
+      assert !u.valid?
+      assert u.errors[:login].size > 0
+
+      u.login = "@atmark"
+      assert !u.valid?
+      assert u.errors[:login].size > 0
+
+      u.login = "+plus"
+      assert !u.valid?
+      assert u.errors[:login].size > 0
     end
 
     def test_validates_uniqueness_of_login_field


### PR DESCRIPTION
* Modified regex
* Added test_validates_format_of_login_field

## Modified regex
`/\A\w[\w\.+\-_@ ]+\z/` =>
`/\A[a-zA-Z0-9][a-zA-Z0-9\.+\-_@ ]+\z/`

## why
```
$ ruby -cw lib/authlogic/regex.rb
lib/authlogic/regex.rb:44: warning: character class has duplicated range: /\A\w[\w\.+\-_@ ]+\z/
```
because `\w` is `[a-zA-Z0-0_]`. 
that is current regex has duplicated _(underscore).

By the way, I think to wrong initial character has allowed _(underscore) on regex.
So, Changes not allowed _(underscore) on initial character.

e.g. `u.login = "_underscore"`
before  `u.valid? # => true`
after `u.valid? # => false`