### PR TITLE
Fixes test warning for ActiveSupport.test_order option

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,11 @@ ActiveRecord::Base.logger = logger
 if (ActiveRecord::VERSION::STRING < '4.1')
   ActiveRecord::Base.configurations = true
 end
+
+if ActiveSupport.respond_to?(:test_order)
+  ActiveSupport.test_order = :random
+end
+
 ActiveRecord::Base.default_timezone = :local
 ActiveRecord::Schema.define(:version => 1) do
   create_table :companies do |t|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ if (ActiveRecord::VERSION::STRING < '4.1')
 end
 
 if ActiveSupport.respond_to?(:test_order)
-  ActiveSupport.test_order = :random
+  ActiveSupport.test_order = :sorted
 end
 
 ActiveRecord::Base.default_timezone = :local


### PR DESCRIPTION
Fixes test warning
```
DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`. In Rails 5, the default value of this option will change from `:sorted` to `:random`.
To disable this warning and keep the current behavior, you can add the following line to your `config/environments/test.rb`:

  Rails.application.configure do
    config.active_support.test_order = :sorted
  end

Alternatively, you can opt into the future behavior by setting this option to `:random`. (called from test_order at /Users/naberon/work/gem/authlogic/vendor/bundler/ruby/2.2.0/gems/activesupport-4.2.3/lib/active_support/test_case.rb:42)
```