### PR TITLE
Avoid save(false) deprecation warning

### DIFF
--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -24,7 +24,7 @@ module Authlogic
           add_acts_as_authentic_module(Methods)
         end
       end
-      
+
       module Config
         # This is more of a convenience method. In order to turn off automatic maintenance of sessions just
         # set this to false, or you can also set the session_ids method to a blank array. Both accomplish
@@ -36,7 +36,7 @@ module Authlogic
           rw_config(:maintain_sessions, value, true)
         end
         alias_method :maintain_sessions=, :maintain_sessions
-        
+
         # As you may know, authlogic sessions can be separate by id (See Authlogic::Session::Base#id). You can
         # specify here what session ids you want auto maintained. By default it is the main session, which has
         # an id of nil.
@@ -47,7 +47,7 @@ module Authlogic
           rw_config(:session_ids, value, [nil])
         end
         alias_method :session_ids=, :session_ids
-        
+
         # The name of the associated session class. This is inferred by the name of the model.
         #
         # * <tt>Default:</tt> "#{klass.name}Session".constantize
@@ -58,7 +58,7 @@ module Authlogic
         end
         alias_method :session_class=, :session_class
       end
-      
+
       module Methods
         def self.included(klass)
           klass.class_eval do
@@ -66,38 +66,38 @@ module Authlogic
             before_save :maintain_sessions, :if => :update_sessions?
           end
         end
-        
+
         # Save the record and skip session maintenance all together.
-        def save_without_session_maintenance(*args)
+        def save_without_session_maintenance(validate=true)
           self.skip_session_maintenance = true
-          result = save(*args)
+          result = save(:validate => validate)
           self.skip_session_maintenance = false
           result
         end
-        
+
         private
           def skip_session_maintenance=(value)
             @skip_session_maintenance = value
           end
-          
+
           def skip_session_maintenance
             @skip_session_maintenance ||= false
           end
-          
+
           def update_sessions?
             !skip_session_maintenance && session_class && session_class.activated? && self.class.maintain_sessions == true && !session_ids.blank? && persistence_token_changed?
           end
-          
+
           def get_session_information
             # Need to determine if we are completely logged out, or logged in as another user
             @_sessions = []
-            
+
             session_ids.each do |session_id|
               session = session_class.find(session_id, self)
               @_sessions << session if session && session.record
             end
           end
-          
+
           def maintain_sessions
             if @_sessions.empty?
               create_session
@@ -105,7 +105,7 @@ module Authlogic
               update_sessions
             end
           end
-          
+
           def create_session
             # We only want to automatically login into the first session, since this is the main session. The other sessions are sessions
             # that need to be created after logging into the main session.
@@ -114,7 +114,7 @@ module Authlogic
 
             return true
           end
-          
+
           def update_sessions
             # We found sessions above, let's update them with the new info
             @_sessions.each do |stale_session|
@@ -125,11 +125,11 @@ module Authlogic
 
             return true
           end
-          
+
           def session_ids
             self.class.session_ids
           end
-          
+
           def session_class
             self.class.session_class
           end


### PR DESCRIPTION
Avoid deprecation warning:
DEPRECATION WARNING: save(false) is deprecated, please give save(:validate => false) instead. (called from save_without_session_maintenance at /Library/Ruby/Gems/2.0.0/gems/authlogic-2.1.6/lib/authlogic/acts_as_authentic/session_maintenance.rb:73)