### PR TITLE
Increased minimum password length from 4 to 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * changes
-  * ...
+  * increased default minimum password length to 8 (@iainbeeston)
 
 ## 3.4.6 2015
 

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -89,10 +89,10 @@ module Authlogic
         # merge options into it. Checkout the convenience function merge_validates_length_of_password_field_options to merge
         # options.</b>
         #
-        # * <tt>Default:</tt> {:minimum => 4, :if => :require_password?}
+        # * <tt>Default:</tt> {:minimum => 8, :if => :require_password?}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_length_of
         def validates_length_of_password_field_options(value = nil)
-          rw_config(:validates_length_of_password_field_options, value, {:minimum => 4, :if => :require_password?})
+          rw_config(:validates_length_of_password_field_options, value, {:minimum => 8, :if => :require_password?})
         end
         alias_method :validates_length_of_password_field_options=, :validates_length_of_password_field_options
 

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -51,7 +51,7 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_length_of_password_field_options_config
-      default = {:minimum => 4, :if => :require_password?}
+      default = {:minimum => 8, :if => :require_password?}
       assert_equal default, User.validates_length_of_password_field_options
       assert_equal default, Employee.validates_length_of_password_field_options
 
@@ -73,7 +73,7 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_length_of_password_confirmation_field_options_config
-      default = {:minimum => 4, :if => :require_password?}
+      default = {:minimum => 8, :if => :require_password?}
       assert_equal default, User.validates_length_of_password_confirmation_field_options
       assert_equal default, Employee.validates_length_of_password_confirmation_field_options
 
@@ -104,21 +104,21 @@ module ActsAsAuthenticTest
     end
 
     def test_validates_length_of_password
-      u = User.new(login: "abcde", email: "abcde@test.com", password: "abcde", password_confirmation: "abcde")
+      u = User.new(login: "abcde", email: "abcde@test.com", password: "abcdefgh", password_confirmation: "abcdefgh")
       assert u.valid?
 
-      u.password = u.password_confirmation = "abc"
+      u.password = u.password_confirmation = "abcdef"
       assert !u.valid?
 
-      assert u.errors[:password].include?("is too short (minimum is 4 characters)")
-      assert u.errors[:password_confirmation].include?("is too short (minimum is 4 characters)")
+      assert u.errors[:password].include?("is too short (minimum is 8 characters)")
+      assert u.errors[:password_confirmation].include?("is too short (minimum is 8 characters)")
     end
 
     def test_validates_confirmation_of_password
-      u = User.new(login: "abcde", email: "abcde@test.com", password: "abcde", password_confirmation: "abcde")
+      u = User.new(login: "abcde", email: "abcde@test.com", password: "abcdefgh", password_confirmation: "abcdefgh")
       assert u.valid?
 
-      u.password_confirmation = "abcdefgh"
+      u.password_confirmation = "abcdefghij"
       assert !u.valid?
 
       if ActiveModel.respond_to?(:version) and ActiveModel.version.segments.first >= 4
@@ -131,23 +131,23 @@ module ActsAsAuthenticTest
     def test_validates_length_of_password_confirmation
       u = User.new
 
-      u.password = "test"
+      u.password = "testpass"
       u.password_confirmation = ""
       assert !u.valid?
       assert u.errors[:password_confirmation].size > 0
 
-      u.password_confirmation = "test"
+      u.password_confirmation = "testpass"
       assert !u.valid?
       assert u.errors[:password_confirmation].size == 0
 
       ben = users(:ben)
       assert ben.valid?
 
-      ben.password = "newpass"
+      ben.password = "newpasswd"
       assert !ben.valid?
       assert ben.errors[:password_confirmation].size > 0
 
-      ben.password_confirmation = "newpass"
+      ben.password_confirmation = "newpasswd"
       assert ben.valid?
     end
 

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -11,15 +11,15 @@ module ActsAsAuthenticTest
     end
     
     def test_login_after_create
-      assert User.create(:login => "awesome", :password => "saweet", :password_confirmation => "saweet", :email => "awesome@awesome.com")
+      assert User.create(:login => "awesome", :password => "saweeeet", :password_confirmation => "saweeeet", :email => "awesome@awesome.com")
       assert UserSession.find
     end
     
     def test_updating_session_with_failed_magic_state
       ben = users(:ben)
       ben.confirmed = false
-      ben.password = "newpass"
-      ben.password_confirmation = "newpass"
+      ben.password = "newpasswd"
+      ben.password_confirmation = "newpasswd"
       assert ben.save
     end
 
@@ -28,8 +28,8 @@ module ActsAsAuthenticTest
       UserSession.create(ben)
       old_session_key = controller.session["user_credentials"]
       old_cookie_key = controller.cookies["user_credentials"]
-      ben.password = "newpass"
-      ben.password_confirmation = "newpass"
+      ben.password = "newpasswd"
+      ben.password_confirmation = "newpasswd"
       assert ben.save
       assert controller.session["user_credentials"]
       assert controller.cookies["user_credentials"]
@@ -64,8 +64,8 @@ module ActsAsAuthenticTest
       old_session_key = controller.session["user_credentials"]
       old_cookie_key = controller.cookies["user_credentials"]
       zack = users(:zack)
-      zack.password = "newpass"
-      zack.password_confirmation = "newpass"
+      zack.password = "newpasswd"
+      zack.password_confirmation = "newpasswd"
       assert zack.save
       assert_equal controller.session["user_credentials"], old_session_key
       assert_equal controller.cookies["user_credentials"], old_cookie_key
@@ -74,8 +74,8 @@ module ActsAsAuthenticTest
     def test_resetting_password_when_logged_out
       ben = users(:ben)
       assert !UserSession.find
-      ben.password = "newpass"
-      ben.password_confirmation = "newpass"
+      ben.password = "newpasswd"
+      ben.password_confirmation = "newpasswd"
       assert ben.save
       assert UserSession.find
       assert_equal ben, UserSession.find.record


### PR DESCRIPTION
Previously, the (default) minimum password length in authlogic was 4. This seems like a very insecure default. It is still possible to override the minimum password length to maintain the old behaviour, but it ensures that most apps using authlogic will require 8 characters for new or changed passwords, going forward.