### PR TITLE
Fix deprecation warning: prepend_before_filter in Rails 5

### DIFF
--- a/lib/authlogic/controller_adapters/rails_adapter.rb
+++ b/lib/authlogic/controller_adapters/rails_adapter.rb
@@ -35,7 +35,7 @@ module Authlogic
               " authlogic first to get rid of this error.")
           end
           
-          klass.prepend_before_filter :activate_authlogic
+          klass.prepend_before_action :activate_authlogic
         end
         
         private


### PR DESCRIPTION
This fixes deprecation warning:

```
DEPRECATION WARNING: prepend_before_filter is deprecated and will be removed in Rails 5.1. Use prepend_before_action instead. 
```