### PR TITLE
Clarify support of rails 5 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Authlogic
 
-**Authlogic supports both rails 3 and 4. For rails 2, see the [rails2 branch](https://github.com/binarylogic/authlogic/tree/rails2).**
+**Authlogic supports rails >= 3.2. For rails 2, see the [rails2 branch](https://github.com/binarylogic/authlogic/tree/rails2).**
 
 [![Gem Version](https://badge.fury.io/rb/authlogic.png)](http://badge.fury.io/rb/authlogic)
 [![Build Status](https://travis-ci.org/binarylogic/authlogic.png?branch=master)](https://travis-ci.org/binarylogic/authlogic)


### PR DESCRIPTION
Based on the gemspec, authlogic supports rails >= 3.2

.... but then I saw this: https://github.com/binarylogic/authlogic/issues/492 where people claim it doesn't support rails 5. So, I guess either way there's a problem: the gemspec and the readme don't agree! :)