### PR TITLE
Fixing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
+
+before_install:
+  - gem update bundler
+
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 
 gemfile:
   - test/gemfiles/Gemfile.rails-3.2.x
@@ -15,4 +19,8 @@ matrix:
   exclude:
     - rvm: 1.9.3
       gemfile: test/gemfiles/Gemfile.rails-4.1.x
+    - rvm: 2.2.5
+      gemfile: test/gemfiles/Gemfile.rails-3.2.x
+    - rvm: 2.3.1
+      gemfile: test/gemfiles/Gemfile.rails-3.2.x
   fast_finish: true

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'activerecord', '>= 3.2'
-  s.add_dependency 'activesupport', '>= 3.2'
+  s.add_dependency 'activerecord', ['>= 3.2', '< 5.0']
+  s.add_dependency 'activesupport', ['>= 3.2', '< 5.0']
   s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'scrypt', '>= 1.2', '< 3.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'


### PR DESCRIPTION
### Fixes ruby 1.9.3

With ruby 1.9.3, `bundle install` was failing on CI.

```
NoMethodError: undefined method `spec' for nil:NilClass
An error occurred while installing authlogic (3.4.6), and Bundler cannot continue.
```

It was suggested by @febeling to upgrade bundler by configuring:

```
before_install:
  - "gem install bundler"
```

or something like that. I went with `gem update bundler`, which seems to work.

### Drops ruby 2.0, adds 2.3

I also dropped ruby 2.0 from the CI matrix and added 2.3. We could keep 2.0 for a little while longer if people want.  `¯\_(ツ)_/¯`

### Constrains rails < 5 in gemspec

In the current state of affairs, authlogic does not work with rails 5. See, e.g. https://github.com/binarylogic/authlogic/pull/488. It's important that the gemspec reflect this.