### PR TITLE
Allow scrypt 3

### DIFF
--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', ['>= 3.2', '< 5.0']
   s.add_dependency 'activesupport', ['>= 3.2', '< 5.0']
   s.add_dependency 'request_store', '~> 1.0'
-  s.add_dependency 'scrypt', '>= 1.2', '< 3.0'
+  s.add_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'
   s.add_development_dependency 'timecop', '~> 0.7'
 


### PR DESCRIPTION
scrypt 3 is backwards compatible with scrypt 2, there are no breaking changes.

- https://github.com/pbhogan/scrypt/blob/master/CHANGELOG.md
- https://github.com/pbhogan/scrypt/pull/57