### PR TITLE
Lint: Improve Metrics/LineLength to 140

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,10 @@ AllCops:
   # lowest version of MRI that authlogic supports.
   TargetRubyVersion: 1.9
 
+# Compared to metrics like AbcSize, MethodLength has questionable value.
+Metrics/MethodLength:
+  Enabled: false
+
 # Please use normal indentation when aligning parameters.
 #
 # Good:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,11 +70,8 @@ Lint/UselessAccessModifier:
 Metrics/AbcSize:
   Max: 82
 
-# Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 187
-  Exclude:
-    - 'test/**/*'
+  Enabled: false
 
 Metrics/CyclomaticComplexity:
   Max: 12
@@ -82,17 +79,10 @@ Metrics/CyclomaticComplexity:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
 # URISchemes: http, https
 Metrics/LineLength:
-  Max: 160
+  Max: 140
 
-# Configuration parameters: CountComments.
-Metrics/MethodLength:
-  Max: 31
-  Exclude:
-    - 'test/**/*'
-
-# Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 106
+  Enabled: false
 
 Metrics/PerceivedComplexity:
   Max: 13
@@ -271,6 +261,9 @@ Style/ModuleFunction:
   Exclude:
     - 'lib/authlogic/random.rb'
 
+Style/MultilineOperationIndentation:
+  Enabled: false
+
 Style/MultilineTernaryOperator:
   Exclude:
     - 'lib/authlogic/acts_as_authentic/password.rb'
@@ -306,8 +299,7 @@ Style/NegatedIf:
 # Configuration parameters: EnforcedStyle, MinBodyLength, SupportedStyles.
 # SupportedStyles: skip_modifier_ifs, always
 Style/Next:
-  Exclude:
-    - 'lib/authlogic/acts_as_authentic/password.rb'
+  Enabled: false
 
 # Cop supports --auto-correct.
 Style/Not:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,20 @@ Tests can be ran against different versions of Rails like so:
 
 ```
 BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-3.2.x bundle install
-BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-3.2.x bundle exec rake test
+BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-3.2.x bundle exec rake
 ```
 
 ### Linting
 
-Running `rake test` also runs a linter, rubocop. Contributions must pass both
+Running `rake` also runs a linter, rubocop. Contributions must pass both
 the linter and the tests. The linter can be run on its own.
 
 ```
 BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-3.2.x bundle exec rubocop
+```
+
+To run the tests without linting, use `rake test`.
+
+```
+BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-3.2.x bundle exec rake test
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -15,9 +15,7 @@ Rake::TestTask.new(:test) do |test|
   test.ruby_opts += ["-W1"]
 end
 
-# Run linter (rubocop) before tests.
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
-task :test => :rubocop
 
-task :default => :test
+task :default => [:rubocop, :test]

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -1,7 +1,8 @@
 module Authlogic
   module ActsAsAuthentic
-    # This module has a lot of neat functionality. It is responsible for encrypting your password, salting it, and verifying it.
-    # It can also help you transition to a new encryption algorithm. See the Config sub module for configuration options.
+    # This module has a lot of neat functionality. It is responsible for encrypting your
+    # password, salting it, and verifying it. It can also help you transition to a new
+    # encryption algorithm. See the Config sub module for configuration options.
     module Password
       def self.included(klass)
         klass.class_eval do
@@ -18,7 +19,11 @@ module Authlogic
         # * <tt>Default:</tt> :crypted_password, :encrypted_password, :password_hash, or :pw_hash
         # * <tt>Accepts:</tt> Symbol
         def crypted_password_field(value = nil)
-          rw_config(:crypted_password_field, value, first_column_to_exist(nil, :crypted_password, :encrypted_password, :password_hash, :pw_hash))
+          rw_config(
+            :crypted_password_field,
+            value,
+            first_column_to_exist(nil, :crypted_password, :encrypted_password, :password_hash, :pw_hash)
+          )
         end
         alias_method :crypted_password_field=, :crypted_password_field
 
@@ -27,12 +32,16 @@ module Authlogic
         # * <tt>Default:</tt> :password_salt, :pw_salt, :salt, nil if none exist
         # * <tt>Accepts:</tt> Symbol
         def password_salt_field(value = nil)
-          rw_config(:password_salt_field, value, first_column_to_exist(nil, :password_salt, :pw_salt, :salt))
+          rw_config(
+            :password_salt_field,
+            value,
+            first_column_to_exist(nil, :password_salt, :pw_salt, :salt)
+          )
         end
         alias_method :password_salt_field=, :password_salt_field
 
-        # Whether or not to require a password confirmation. If you don't want your users to confirm their password
-        # just set this to false.
+        # Whether or not to require a password confirmation. If you don't want your users
+        # to confirm their password just set this to false.
         #
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
@@ -41,14 +50,17 @@ module Authlogic
         end
         alias_method :require_password_confirmation=, :require_password_confirmation
 
-        # By default passwords are required when a record is new or the crypted_password is blank, but if both of these things
-        # are met a password is not required. In this case, blank passwords are ignored.
+        # By default passwords are required when a record is new or the crypted_password
+        # is blank, but if both of these things are met a password is not required. In
+        # this case, blank passwords are ignored.
         #
-        # Think about a profile page, where the user can edit all of their information, including changing their password.
-        # If they do not want to change their password they just leave the fields blank. This will try to set the password to
-        # a blank value, in which case is incorrect behavior. As such, Authlogic ignores this. But let's say you have a completely
-        # separate page for resetting passwords, you might not want to ignore blank passwords. If this is the case for you, then
-        # just set this value to false.
+        # Think about a profile page, where the user can edit all of their information,
+        # including changing their password. If they do not want to change their password
+        # they just leave the fields blank. This will try to set the password to a blank
+        # value, in which case is incorrect behavior. As such, Authlogic ignores this. But
+        # let's say you have a completely separate page for resetting passwords, you might
+        # not want to ignore blank passwords. If this is the case for you, then just set
+        # this value to false.
         #
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
@@ -57,15 +69,16 @@ module Authlogic
         end
         alias_method :ignore_blank_passwords=, :ignore_blank_passwords
 
-        # When calling valid_password?("some pass") do you want to check that password against what's in that object or whats in
-        # the database. Take this example:
+        # When calling valid_password?("some pass") do you want to check that password
+        # against what's in that object or whats in the database. Take this example:
         #
         #   u = User.first
         #   u.password = "new pass"
         #   u.valid_password?("old pass")
         #
-        # Should the last line above return true or false? The record hasn't been saved yet, so most would assume true.
-        # Other would assume false. So I let you decide by giving you this option.
+        # Should the last line above return true or false? The record hasn't been saved
+        # yet, so most would assume true. Other would assume false. So I let you decide by
+        # giving you this option.
         #
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
@@ -83,10 +96,12 @@ module Authlogic
         end
         alias_method :validate_password_field=, :validate_password_field
 
-        # A hash of options for the validates_length_of call for the password field. Allows you to change this however you want.
+        # A hash of options for the validates_length_of call for the password field.
+        # Allows you to change this however you want.
         #
-        # <b>Keep in mind this is ruby. I wanted to keep this as flexible as possible, so you can completely replace the hash or
-        # merge options into it. Checkout the convenience function merge_validates_length_of_password_field_options to merge
+        # <b>Keep in mind this is ruby. I wanted to keep this as flexible as possible, so
+        # you can completely replace the hash or merge options into it. Checkout the
+        # convenience function merge_validates_length_of_password_field_options to merge
         # options.</b>
         #
         # * <tt>Default:</tt> {:minimum => 8, :if => :require_password?}
@@ -96,9 +111,11 @@ module Authlogic
         end
         alias_method :validates_length_of_password_field_options=, :validates_length_of_password_field_options
 
-        # A convenience function to merge options into the validates_length_of_login_field_options. So instead of:
+        # A convenience function to merge options into the
+        # validates_length_of_login_field_options. So instead of:
         #
-        #   self.validates_length_of_password_field_options = validates_length_of_password_field_options.merge(:my_option => my_value)
+        #   self.validates_length_of_password_field_options =
+        #     validates_length_of_password_field_options.merge(:my_option => my_value)
         #
         # You can do this:
         #
@@ -107,10 +124,12 @@ module Authlogic
           self.validates_length_of_password_field_options = validates_length_of_password_field_options.merge(options)
         end
 
-        # A hash of options for the validates_confirmation_of call for the password field. Allows you to change this however you want.
+        # A hash of options for the validates_confirmation_of call for the password field.
+        # Allows you to change this however you want.
         #
-        # <b>Keep in mind this is ruby. I wanted to keep this as flexible as possible, so you can completely replace the hash or
-        # merge options into it. Checkout the convenience function merge_validates_length_of_password_field_options to merge
+        # <b>Keep in mind this is ruby. I wanted to keep this as flexible as possible, so
+        # you can completely replace the hash or merge options into it. Checkout the
+        # convenience function merge_validates_length_of_password_field_options to merge
         # options.</b>
         #
         # * <tt>Default:</tt> {:if => :require_password?}
@@ -120,31 +139,41 @@ module Authlogic
         end
         alias_method :validates_confirmation_of_password_field_options=, :validates_confirmation_of_password_field_options
 
-        # See merge_validates_length_of_password_field_options. The same thing, except for validates_confirmation_of_password_field_options
+        # See merge_validates_length_of_password_field_options. The same thing, except for
+        # validates_confirmation_of_password_field_options
         def merge_validates_confirmation_of_password_field_options(options = {})
           self.validates_confirmation_of_password_field_options = validates_confirmation_of_password_field_options.merge(options)
         end
 
-        # A hash of options for the validates_length_of call for the password_confirmation field. Allows you to change this however you want.
+        # A hash of options for the validates_length_of call for the password_confirmation
+        # field. Allows you to change this however you want.
         #
-        # <b>Keep in mind this is ruby. I wanted to keep this as flexible as possible, so you can completely replace the hash or
-        # merge options into it. Checkout the convenience function merge_validates_length_of_password_field_options to merge
+        # <b>Keep in mind this is ruby. I wanted to keep this as flexible as possible, so
+        # you can completely replace the hash or merge options into it. Checkout the
+        # convenience function merge_validates_length_of_password_field_options to merge
         # options.</b>
         #
         # * <tt>Default:</tt> validates_length_of_password_field_options
         # * <tt>Accepts:</tt> Hash of options accepted by validates_length_of
         def validates_length_of_password_confirmation_field_options(value = nil)
-          rw_config(:validates_length_of_password_confirmation_field_options, value, validates_length_of_password_field_options)
+          rw_config(
+            :validates_length_of_password_confirmation_field_options,
+            value,
+            validates_length_of_password_field_options
+          )
         end
         alias_method :validates_length_of_password_confirmation_field_options=, :validates_length_of_password_confirmation_field_options
 
-        # See merge_validates_length_of_password_field_options. The same thing, except for validates_length_of_password_confirmation_field_options
+        # See merge_validates_length_of_password_field_options. The same thing, except for
+        # validates_length_of_password_confirmation_field_options
         def merge_validates_length_of_password_confirmation_field_options(options = {})
-          self.validates_length_of_password_confirmation_field_options = validates_length_of_password_confirmation_field_options.merge(options)
+          self.validates_length_of_password_confirmation_field_options =
+            validates_length_of_password_confirmation_field_options.merge(options)
         end
 
-        # The class you want to use to encrypt and verify your encrypted passwords. See the Authlogic::CryptoProviders module for more info
-        # on the available methods and how to create your own.
+        # The class you want to use to encrypt and verify your encrypted passwords. See
+        # the Authlogic::CryptoProviders module for more info on the available methods and
+        # how to create your own.
         #
         # * <tt>Default:</tt> CryptoProviders::SCrypt
         # * <tt>Accepts:</tt> Class
@@ -153,14 +182,17 @@ module Authlogic
         end
         alias_method :crypto_provider=, :crypto_provider
 
-        # Let's say you originally encrypted your passwords with Sha1. Sha1 is starting to join the party with MD5 and you want to switch
-        # to something stronger. No problem, just specify your new and improved algorithm with the crypt_provider option and then let
-        # Authlogic know you are transitioning from Sha1 using this option. Authlogic will take care of everything, including transitioning
-        # your users to the new algorithm. The next time a user logs in, they will be granted access using the old algorithm and their
-        # password will be resaved with the new algorithm. All new users will obviously use the new algorithm as well.
+        # Let's say you originally encrypted your passwords with Sha1. Sha1 is starting to
+        # join the party with MD5 and you want to switch to something stronger. No
+        # problem, just specify your new and improved algorithm with the crypt_provider
+        # option and then let Authlogic know you are transitioning from Sha1 using this
+        # option. Authlogic will take care of everything, including transitioning your
+        # users to the new algorithm. The next time a user logs in, they will be granted
+        # access using the old algorithm and their password will be resaved with the new
+        # algorithm. All new users will obviously use the new algorithm as well.
         #
-        # Lastly, if you want to transition again, you can pass an array of crypto providers. So you can transition from as many algorithms
-        # as you want.
+        # Lastly, if you want to transition again, you can pass an array of crypto
+        # providers. So you can transition from as many algorithms as you want.
         #
         # * <tt>Default:</tt> nil
         # * <tt>Accepts:</tt> Class or Array
@@ -248,9 +280,11 @@ module Authlogic
             after_password_set
           end
 
-          # Accepts a raw password to determine if it is the correct password or not. Notice the second argument. That defaults to the value of
-          # check_passwords_against_database. See that method for more information, but basically it just tells Authlogic to check the password
-          # against the value in the database or the value in the object.
+          # Accepts a raw password to determine if it is the correct password or not.
+          # Notice the second argument. That defaults to the value of
+          # check_passwords_against_database. See that method for more information, but
+          # basically it just tells Authlogic to check the password against the value in
+          # the database or the value in the object.
           def valid_password?(attempted_password, check_against_database = check_passwords_against_database?)
             crypted =
               if check_against_database && send("#{crypted_password_field}_changed?")

--- a/lib/authlogic/acts_as_authentic/single_access_token.rb
+++ b/lib/authlogic/acts_as_authentic/single_access_token.rb
@@ -1,7 +1,8 @@
 module Authlogic
   module ActsAsAuthentic
-    # This module is responsible for maintaining the single_access token. For more information the single access token and how to use it,
-    # see the Authlogic::Session::Params module.
+    # This module is responsible for maintaining the single_access token. For more
+    # information the single access token and how to use it, see the
+    # Authlogic::Session::Params module.
     module SingleAccessToken
       def self.included(klass)
         klass.class_eval do
@@ -12,10 +13,10 @@ module Authlogic
 
       # All configuration for the single_access token aspect of acts_as_authentic.
       module Config
-        # The single access token is used for authentication via URLs, such as a private feed. That being said,
-        # if the user changes their password, that token probably shouldn't change. If it did, the user would have
-        # to update all of their URLs. So be default this is option is disabled, if you need it, feel free to turn
-        # it on.
+        # The single access token is used for authentication via URLs, such as a private
+        # feed. That being said, if the user changes their password, that token probably
+        # shouldn't change. If it did, the user would have to update all of their URLs. So
+        # be default this is option is disabled, if you need it, feel free to turn it on.
         #
         # * <tt>Default:</tt> false
         # * <tt>Accepts:</tt> Boolean
@@ -34,7 +35,9 @@ module Authlogic
             include InstanceMethods
             validates_uniqueness_of :single_access_token, :if => :single_access_token_changed?
             before_validation :reset_single_access_token, :if => :reset_single_access_token?
-            after_password_set(:reset_single_access_token, :if => :change_single_access_token_with_password?) if respond_to?(:after_password_set)
+            if respond_to?(:after_password_set)
+              after_password_set(:reset_single_access_token, :if => :change_single_access_token_with_password?)
+            end
           end
         end
 

--- a/lib/authlogic/authenticates_many/base.rb
+++ b/lib/authlogic/authenticates_many/base.rb
@@ -1,6 +1,7 @@
 module Authlogic
-  # This allows you to scope your authentication. For example, let's say all users belong to an account, you want to make sure only users
-  # that belong to that account can actually login into that account. Simple, just do:
+  # This allows you to scope your authentication. For example, let's say all users belong
+  # to an account, you want to make sure only users that belong to that account can
+  # actually login into that account. Simple, just do:
   #
   #   class Account < ActiveRecord::Base
   #     authenticates_many :user_sessions
@@ -17,7 +18,8 @@ module Authlogic
   # You may also want to checkout Authlogic::ActsAsAuthentic::Scope to scope your model.
   module AuthenticatesMany
     module Base
-      # Allows you set essentially set up a relationship with your sessions. See module definition above for more details.
+      # Allows you set essentially set up a relationship with your sessions. See module
+      # definition above for more details.
       #
       # === Options
       #
@@ -25,18 +27,26 @@ module Authlogic
       #   This is the related session class.
       #
       # * <tt>relationship_name:</tt> default: options[:session_class].klass_name.underscore.pluralize,
-      #   This is the name of the relationship you want to use to scope everything. For example an Account has many Users. There should be a relationship
-      #   called :users that you defined with a has_many. The reason we use the relationship is so you don't have to repeat yourself. The relationship
-      #   could have all kinds of custom options. So instead of repeating yourself we essentially use the scope that the relationship creates.
+      #   This is the name of the relationship you want to use to scope everything. For
+      #   example an Account has many Users. There should be a relationship called :users
+      #   that you defined with a has_many. The reason we use the relationship is so you
+      #   don't have to repeat yourself. The relationship could have all kinds of custom
+      #   options. So instead of repeating yourself we essentially use the scope that the
+      #   relationship creates.
       #
       # * <tt>find_options:</tt> default: nil,
-      #   By default the find options are created from the relationship you specify with :relationship_name. But if you want to override this and
-      #   manually specify find_options you can do it here. Specify options just as you would in ActiveRecord::Base.find.
+      #   By default the find options are created from the relationship you specify with
+      #   :relationship_name. But if you want to override this and manually specify
+      #   find_options you can do it here. Specify options just as you would in
+      #   ActiveRecord::Base.find.
       #
       # * <tt>scope_cookies:</tt> default: false
-      #   By the nature of cookies they scope themselves if you are using subdomains to access accounts. If you aren't using subdomains you need to have
-      #   separate cookies for each account, assuming a user is logging into mroe than one account. Authlogic can take care of this for you by
-      #   prefixing the name of the cookie and sessin with the model id. You just need to tell Authlogic to do this by passing this option.
+      #   By the nature of cookies they scope themselves if you are using subdomains to
+      #   access accounts. If you aren't using subdomains you need to have separate
+      #   cookies for each account, assuming a user is logging into mroe than one account.
+      #   Authlogic can take care of this for you by prefixing the name of the cookie and
+      #   sessin with the model id. You just need to tell Authlogic to do this by passing
+      #   this option.
       def authenticates_many(name, options = {})
         options[:session_class] ||= name.to_s.classify.constantize
         options[:relationship_name] ||= options[:session_class].klass_name.underscore.pluralize

--- a/lib/authlogic/crypto_providers/aes256.rb
+++ b/lib/authlogic/crypto_providers/aes256.rb
@@ -2,18 +2,21 @@ require "openssl"
 
 module Authlogic
   module CryptoProviders
-    # This encryption method is reversible if you have the supplied key. So in order to use this encryption method you must supply it with a key first.
-    # In an initializer, or before your application initializes, you should do the following:
+    # This encryption method is reversible if you have the supplied key. So in order to
+    # use this encryption method you must supply it with a key first. In an initializer,
+    # or before your application initializes, you should do the following:
     #
     #   Authlogic::CryptoProviders::AES256.key = "my really long and unique key, preferably a bunch of random characters"
     #
-    # My final comment is that this is a strong encryption method, but its main weakness is that it's reversible. If you do not need to reverse the hash
-    # then you should consider Sha512 or BCrypt instead.
+    # My final comment is that this is a strong encryption method, but its main weakness
+    # is that it's reversible. If you do not need to reverse the hash then you should
+    # consider Sha512 or BCrypt instead.
     #
-    # Keep your key in a safe place, some even say the key should be stored on a separate server.
-    # This won't hurt performance because the only time it will try and access the key on the separate server is during initialization, which only
-    # happens once. The reasoning behind this is if someone does compromise your server they won't have the key also. Basically, you don't want to
-    # store the key with the lock.
+    # Keep your key in a safe place, some even say the key should be stored on a separate
+    # server. This won't hurt performance because the only time it will try and access the
+    # key on the separate server is during initialization, which only happens once. The
+    # reasoning behind this is if someone does compromise your server they won't have the
+    # key also. Basically, you don't want to store the key with the lock.
     class AES256
       class << self
         attr_writer :key

--- a/lib/authlogic/random.rb
+++ b/lib/authlogic/random.rb
@@ -1,10 +1,12 @@
 module Authlogic
-  # Handles generating random strings. If SecureRandom is installed it will default to this and use it instead. SecureRandom comes with ActiveSupport.
-  # So if you are using this in a rails app you should have this library.
+  # Handles generating random strings. If SecureRandom is installed it will default to
+  # this and use it instead. SecureRandom comes with ActiveSupport. So if you are using
+  # this in a rails app you should have this library.
   module Random
     extend self
 
-    SecureRandom = (defined?(::SecureRandom) && ::SecureRandom) || (defined?(::ActiveSupport::SecureRandom) && ::ActiveSupport::SecureRandom)
+    SecureRandom = (defined?(::SecureRandom) && ::SecureRandom) ||
+      (defined?(::ActiveSupport::SecureRandom) && ::ActiveSupport::SecureRandom)
 
     if SecureRandom
       def hex_token

--- a/lib/authlogic/session/brute_force_protection.rb
+++ b/lib/authlogic/session/brute_force_protection.rb
@@ -1,15 +1,21 @@
 module Authlogic
   module Session
-    # A brute force attacks is executed by hammering a login with as many password combinations as possible, until one works. A brute force attacked is
-    # generally combated with a slow hashing algorithm such as BCrypt. You can increase the cost, which makes the hash generation slower, and ultimately
-    # increases the time it takes to execute a brute force attack. Just to put this into perspective, if a hacker was to gain access to your server
-    # and execute a brute force attack locally, meaning there is no network lag, it would probably take decades to complete. Now throw in network lag
-    # and it would take MUCH longer.
+    # A brute force attacks is executed by hammering a login with as many password
+    # combinations as possible, until one works. A brute force attacked is generally
+    # combated with a slow hashing algorithm such as BCrypt. You can increase the cost,
+    # which makes the hash generation slower, and ultimately increases the time it takes
+    # to execute a brute force attack. Just to put this into perspective, if a hacker was
+    # to gain access to your server and execute a brute force attack locally, meaning
+    # there is no network lag, it would probably take decades to complete. Now throw in
+    # network lag and it would take MUCH longer.
     #
-    # But for those that are extra paranoid and can't get enough protection, why not stop them as soon as you realize something isn't right? That's
-    # what this module is all about. By default the consecutive_failed_logins_limit configuration option is set to 50, if someone consecutively fails to login
-    # after 50 attempts their account will be suspended. This is a very liberal number and at this point it should be obvious that something is not right.
-    # If you wish to lower this number just set the configuration to a lower number:
+    # But for those that are extra paranoid and can't get enough protection, why not stop
+    # them as soon as you realize something isn't right? That's what this module is all
+    # about. By default the consecutive_failed_logins_limit configuration option is set to
+    # 50, if someone consecutively fails to login after 50 attempts their account will be
+    # suspended. This is a very liberal number and at this point it should be obvious that
+    # something is not right. If you wish to lower this number just set the configuration
+    # to a lower number:
     #
     #   class UserSession < Authlogic::Session::Base
     #     consecutive_failed_logins_limit 10
@@ -87,11 +93,18 @@ module Authlogic
           end
 
           def validate_failed_logins
-            errors.clear # Clear all other error messages, as they are irrelevant at this point and can only provide additional information that is not needed
-            errors.add(:base, I18n.t(
-              'error_messages.consecutive_failed_logins_limit_exceeded',
-              :default => "Consecutive failed logins limit exceeded, account has been" + (failed_login_ban_for == 0 ? "" : " temporarily") + " disabled."
-            ))
+            # Clear all other error messages, as they are irrelevant at this point and can
+            # only provide additional information that is not needed
+            errors.clear
+            errors.add(
+              :base,
+              I18n.t(
+                'error_messages.consecutive_failed_logins_limit_exceeded',
+                :default => "Consecutive failed logins limit exceeded, account has been" +
+                  (failed_login_ban_for == 0 ? "" : " temporarily") +
+                  " disabled."
+              )
+            )
           end
 
           def consecutive_failed_logins_limit

--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -51,7 +51,8 @@ module Authlogic
         end
         alias_method :remember_me_for=, :remember_me_for
 
-        # Should the cookie be set as secure?  If true, the cookie will only be sent over SSL connections
+        # Should the cookie be set as secure?  If true, the cookie will only be sent over
+        # SSL connections
         #
         # * <tt>Default:</tt> false
         # * <tt>Accepts:</tt> Boolean
@@ -60,7 +61,8 @@ module Authlogic
         end
         alias_method :secure=, :secure
 
-        # Should the cookie be set as httponly?  If true, the cookie will not be accessible from javascript
+        # Should the cookie be set as httponly?  If true, the cookie will not be
+        # accessible from javascript
         #
         # * <tt>Default:</tt> false
         # * <tt>Accepts:</tt> Boolean
@@ -69,7 +71,8 @@ module Authlogic
         end
         alias_method :httponly=, :httponly
 
-        # Should the cookie be signed? If the controller adapter supports it, this is a measure against cookie tampering.
+        # Should the cookie be signed? If the controller adapter supports it, this is a
+        # measure against cookie tampering.
         def sign_cookie(value = nil)
           if value && !controller.cookies.respond_to?(:signed)
             raise "Signed cookies not supported with #{controller.class}!"
@@ -79,7 +82,8 @@ module Authlogic
         alias_method :sign_cookie=, :sign_cookie
       end
 
-      # The methods available for an Authlogic::Session::Base object that make up the cookie feature set.
+      # The methods available for an Authlogic::Session::Base object that make up the
+      # cookie feature set.
       module InstanceMethods
         # Allows you to set the remember_me option when passing credentials.
         def credentials=(value)
@@ -112,13 +116,15 @@ module Authlogic
           remember_me == true || remember_me == "true" || remember_me == "1"
         end
 
-        # How long to remember the user if remember_me is true. This is based on the class level configuration: remember_me_for
+        # How long to remember the user if remember_me is true. This is based on the class
+        # level configuration: remember_me_for
         def remember_me_for
           return unless remember_me?
           self.class.remember_me_for
         end
 
-        # When to expire the cookie. See remember_me_for configuration option to change this.
+        # When to expire the cookie. See remember_me_for configuration option to change
+        # this.
         def remember_me_until
           return unless remember_me?
           remember_me_for.from_now
@@ -136,7 +142,8 @@ module Authlogic
           @secure = self.class.secure
         end
 
-        # Accepts a boolean as to whether the cookie should be marked as secure.  If true the cookie will only ever be sent over an SSL connection.
+        # Accepts a boolean as to whether the cookie should be marked as secure.  If true
+        # the cookie will only ever be sent over an SSL connection.
         def secure=(value)
           @secure = value
         end

--- a/lib/authlogic/session/foundation.rb
+++ b/lib/authlogic/session/foundation.rb
@@ -1,8 +1,8 @@
 module Authlogic
   module Session
-    # Sort of like an interface, it sets the foundation for the class, such as the required methods. This also allows
-    # other modules to overwrite methods and call super on them. It's also a place to put "utility" methods used
-    # throughout Authlogic.
+    # Sort of like an interface, it sets the foundation for the class, such as the
+    # required methods. This also allows other modules to overwrite methods and call super
+    # on them. It's also a place to put "utility" methods used throughout Authlogic.
     module Foundation
       def self.included(klass)
         klass.class_eval do
@@ -16,12 +16,14 @@ module Authlogic
           self.credentials = args
         end
 
-        # The credentials you passed to create your session. See credentials= for more info.
+        # The credentials you passed to create your session. See credentials= for more
+        # info.
         def credentials
           []
         end
 
-        # Set your credentials before you save your session. You can pass a hash of credentials:
+        # Set your credentials before you save your session. You can pass a hash of
+        # credentials:
         #
         #   session.credentials = {:login => "my login", :password => "my password", :remember_me => true}
         #
@@ -29,8 +31,9 @@ module Authlogic
         #
         #   session.credentials = [my_user_object, true]
         #
-        # and if you need to set an id, just pass it last. This value need be the last item in the array you pass, since the id is something that
-        # you control yourself, it should never be set from a hash or a form. Examples:
+        # and if you need to set an id, just pass it last. This value need be the last
+        # item in the array you pass, since the id is something that you control yourself,
+        # it should never be set from a hash or a form. Examples:
         #
         #   session.credentials = [{:login => "my login", :password => "my password", :remember_me => true}, :my_id]
         #   session.credentials = [my_user_object, true, :my_id]

--- a/lib/authlogic/session/magic_states.rb
+++ b/lib/authlogic/session/magic_states.rb
@@ -31,9 +31,11 @@ module Authlogic
 
       # Configuration for the magic states feature.
       module Config
-        # Set this to true if you want to disable the checking of active?, approved?, and confirmed? on your record. This is more or less of a
-        # convenience feature, since 99% of the time if those methods exist and return false you will not want the user logging in. You could
-        # easily accomplish this same thing with a before_validation method or other callbacks.
+        # Set this to true if you want to disable the checking of active?, approved?, and
+        # confirmed? on your record. This is more or less of a convenience feature, since
+        # 99% of the time if those methods exist and return false you will not want the
+        # user logging in. You could easily accomplish this same thing with a
+        # before_validation method or other callbacks.
         #
         # * <tt>Default:</tt> false
         # * <tt>Accepts:</tt> Boolean
@@ -43,7 +45,8 @@ module Authlogic
         alias_method :disable_magic_states=, :disable_magic_states
       end
 
-      # The methods available for an Authlogic::Session::Base object that make up the magic states feature.
+      # The methods available for an Authlogic::Session::Base object that make up the
+      # magic states feature.
       module InstanceMethods
         private
 

--- a/lib/authlogic/session/params.rb
+++ b/lib/authlogic/session/params.rb
@@ -1,15 +1,19 @@
 module Authlogic
   module Session
-    # This module is responsible for authenticating the user via params, which ultimately allows the user to log in using a URL like the following:
+    # This module is responsible for authenticating the user via params, which ultimately
+    # allows the user to log in using a URL like the following:
     #
     #   https://www.domain.com?user_credentials=4LiXF7FiGUppIPubBPey
     #
-    # Notice the token in the URL, this is a single access token. A single access token is used for single access only, it is not persisted. Meaning the user
-    # provides it, Authlogic grants them access, and that's it. If they want access again they need to provide the token again. Authlogic will
-    # *NEVER* try to persist the session after authenticating through this method.
+    # Notice the token in the URL, this is a single access token. A single access token is
+    # used for single access only, it is not persisted. Meaning the user provides it,
+    # Authlogic grants them access, and that's it. If they want access again they need to
+    # provide the token again. Authlogic will *NEVER* try to persist the session after
+    # authenticating through this method.
     #
-    # For added security, this token is *ONLY* allowed for RSS and ATOM requests. You can change this with the configuration. You can also define if
-    # it is allowed dynamically by defining a single_access_allowed? method in your controller. For example:
+    # For added security, this token is *ONLY* allowed for RSS and ATOM requests. You can
+    # change this with the configuration. You can also define if it is allowed dynamically
+    # by defining a single_access_allowed? method in your controller. For example:
     #
     #   class UsersController < ApplicationController
     #     private
@@ -17,8 +21,9 @@ module Authlogic
     #         action_name == "index"
     #       end
     #
-    # Also, by default, this token is permanent. Meaning if the user changes their password, this token will remain the same. It will only change
-    # when it is explicitly reset.
+    # Also, by default, this token is permanent. Meaning if the user changes their
+    # password, this token will remain the same. It will only change when it is explicitly
+    # reset.
     #
     # You can modify all of this behavior with the Config sub module.
     module Params
@@ -83,7 +88,8 @@ module Authlogic
 
             case single_access_allowed_request_types
             when Array
-              single_access_allowed_request_types.include?(controller.request_content_type) || single_access_allowed_request_types.include?(:all)
+              single_access_allowed_request_types.include?(controller.request_content_type) ||
+                single_access_allowed_request_types.include?(:all)
             else
               [:all, :any].include?(single_access_allowed_request_types)
             end

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -23,8 +23,9 @@ module Authlogic
         # You can change what method UserSession calls by specifying it here. Then in your User model you can make that method do
         # anything you want, giving you complete control of how users are found by the UserSession.
         #
-        # Let's take an example: You want to allow users to login by username or email. Set this to the name of the class method
-        # that does this in the User model. Let's call it "find_by_username_or_email"
+        # Let's take an example: You want to allow users to login by username or email.
+        # Set this to the name of the class method that does this in the User model. Let's
+        # call it "find_by_username_or_email"
         #
         #   class User < ActiveRecord::Base
         #     def self.find_by_username_or_email(login)
@@ -32,8 +33,10 @@ module Authlogic
         #     end
         #   end
         #
-        # Now just specify the name of this method for this configuration option and you are all set. You can do anything you
-        # want here. Maybe you allow users to have multiple logins and you want to search a has_many relationship, etc. The sky is the limit.
+        # Now just specify the name of this method for this configuration option and you
+        # are all set. You can do anything you want here. Maybe you allow users to have
+        # multiple logins and you want to search a has_many relationship, etc. The sky is
+        # the limit.
         #
         # * <tt>Default:</tt> "find_by_smart_case_login_field"
         # * <tt>Accepts:</tt> Symbol or String
@@ -42,9 +45,10 @@ module Authlogic
         end
         alias_method :find_by_login_method=, :find_by_login_method
 
-        # The text used to identify credentials (username/password) combination when a bad login attempt occurs.
-        # When you show error messages for a bad login, it's considered good security practice to hide which field
-        # the user has entered incorrectly (the login field or the password field). For a full explanation, see
+        # The text used to identify credentials (username/password) combination when a bad
+        # login attempt occurs. When you show error messages for a bad login, it's
+        # considered good security practice to hide which field the user has entered
+        # incorrectly (the login field or the password field). For a full explanation, see
         # http://www.gnucitizen.org/blog/username-enumeration-vulnerabilities/
         #
         # Example of use:
@@ -79,10 +83,12 @@ module Authlogic
         end
         alias_method :generalize_credentials_error_messages=, :generalize_credentials_error_messages
 
-        # The name of the method you want Authlogic to create for storing the login / username. Keep in mind this is just for your
-        # Authlogic::Session, if you want it can be something completely different than the field in your model. So if you wanted people to
-        # login with a field called "login" and then find users by email this is completely doable. See the find_by_login_method configuration
-        # option for more details.
+        # The name of the method you want Authlogic to create for storing the login /
+        # username. Keep in mind this is just for your Authlogic::Session, if you want it
+        # can be something completely different than the field in your model. So if you
+        # wanted people to login with a field called "login" and then find users by email
+        # this is completely doable. See the find_by_login_method configuration option for
+        # more details.
         #
         # * <tt>Default:</tt> klass.login_field || klass.email_field
         # * <tt>Accepts:</tt> Symbol or String
@@ -181,8 +187,12 @@ module Authlogic
             self.invalid_password = false
 
             # check for blank fields
-            errors.add(login_field, I18n.t('error_messages.login_blank', :default => "cannot be blank")) if send(login_field).blank?
-            errors.add(password_field, I18n.t('error_messages.password_blank', :default => "cannot be blank")) if send("protected_#{password_field}").blank?
+            if send(login_field).blank?
+              errors.add(login_field, I18n.t('error_messages.login_blank', :default => "cannot be blank"))
+            end
+            if send("protected_#{password_field}").blank?
+              errors.add(password_field, I18n.t('error_messages.password_blank', :default => "cannot be blank"))
+            end
             return if errors.count > 0
 
             self.attempted_record = search_for_record(find_by_login_method, send(login_field))

--- a/lib/authlogic/session/scopes.rb
+++ b/lib/authlogic/session/scopes.rb
@@ -2,10 +2,13 @@ require 'request_store'
 
 module Authlogic
   module Session
-    # Authentication can be scoped, and it's easy, you just need to define how you want to scope everything. This should help you:
+    # Authentication can be scoped, and it's easy, you just need to define how you want to
+    # scope everything. This should help you:
     #
-    # 1. Want to scope by a parent object? Ex: An account has many users. Checkout Authlogic::AuthenticatesMany
-    # 2. Want to scope the validations in your model? Ex: 2 users can have the same login under different accounts. See Authlogic::ActsAsAuthentic::Scope
+    # 1. Want to scope by a parent object? Ex: An account has many users.
+    #    Checkout Authlogic::AuthenticatesMany
+    # 2. Want to scope the validations in your model? Ex: 2 users can have the same login
+    #    under different accounts. See Authlogic::ActsAsAuthentic::Scope
     module Scopes # :nodoc:
       def self.included(klass)
         klass.class_eval do
@@ -22,11 +25,15 @@ module Authlogic
           RequestStore.store[:authlogic_scope]
         end
 
-        # What with_scopes focuses on is scoping the query when finding the object and the name of the cookie / session. It works very similar to
-        # ActiveRecord::Base#with_scopes. It accepts a hash with any of the following options:
+        # What with_scopes focuses on is scoping the query when finding the object and the
+        # name of the cookie / session. It works very similar to
+        # ActiveRecord::Base#with_scopes. It accepts a hash with any of the following
+        # options:
         #
-        # * <tt>find_options:</tt> any options you can pass into ActiveRecord::Base.find. This is used when trying to find the record.
-        # * <tt>id:</tt> The id of the session, this gets merged with the real id. For information ids see the id method.
+        # * <tt>find_options:</tt> any options you can pass into ActiveRecord::Base.find.
+        #   This is used when trying to find the record.
+        # * <tt>id:</tt> The id of the session, this gets merged with the real id. For
+        #   information ids see the id method.
         #
         # Here is how you use it:
         #
@@ -34,7 +41,8 @@ module Authlogic
         #     UserSession.find
         #   end
         #
-        # Essentially what the above does is scope the searching of the object with the sql you provided. So instead of:
+        # Essentially what the above does is scope the searching of the object with the
+        # sql you provided. So instead of:
         #
         #   User.where("login = 'ben'").first
         #
@@ -42,7 +50,8 @@ module Authlogic
         #
         #   User.where("login = 'ben' and account_id = 2").first
         #
-        # You will also notice the :id option. This works just like the id method. It scopes your cookies. So the name of your cookie will be:
+        # You will also notice the :id option. This works just like the id method. It
+        # scopes your cookies. So the name of your cookie will be:
         #
         #   account_2_user_credentials
         #

--- a/lib/authlogic/session/session.rb
+++ b/lib/authlogic/session/session.rb
@@ -33,8 +33,9 @@ module Authlogic
           def persist_by_session
             persistence_token, record_id = session_credentials
             if !persistence_token.nil?
-              # Allow finding by persistence token, because when records are created the session is maintained in a before_save, when there is no id.
-              # This is done for performance reasons and to save on queries.
+              # Allow finding by persistence token, because when records are created the
+              # session is maintained in a before_save, when there is no id. This is done
+              # for performance reasons and to save on queries.
               record = record_id.nil? ?
                 search_for_record("find_by_persistence_token", persistence_token.to_s) :
                 search_for_record("find_by_#{klass.primary_key}", record_id.to_s)
@@ -46,7 +47,10 @@ module Authlogic
           end
 
           def session_credentials
-            [controller.session[session_key], controller.session["#{session_key}_#{klass.primary_key}"]].collect { |i| i.nil? ? i : i.to_s }.compact
+            [
+              controller.session[session_key],
+              controller.session["#{session_key}_#{klass.primary_key}"]
+            ].collect { |i| i.nil? ? i : i.to_s }.compact
           end
 
           def session_key

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -165,8 +165,16 @@ module ActsAsAuthenticTest
       ben = users(:ben)
 
       transition_password_to(Authlogic::CryptoProviders::BCrypt, ben)
-      transition_password_to(Authlogic::CryptoProviders::Sha1, ben, [Authlogic::CryptoProviders::Sha512, Authlogic::CryptoProviders::BCrypt])
-      transition_password_to(Authlogic::CryptoProviders::Sha512, ben, [Authlogic::CryptoProviders::Sha1, Authlogic::CryptoProviders::BCrypt])
+      transition_password_to(
+        Authlogic::CryptoProviders::Sha1,
+        ben,
+        [Authlogic::CryptoProviders::Sha512, Authlogic::CryptoProviders::BCrypt]
+      )
+      transition_password_to(
+        Authlogic::CryptoProviders::Sha512,
+        ben,
+        [Authlogic::CryptoProviders::Sha1, Authlogic::CryptoProviders::BCrypt]
+      )
     end
 
     def test_checks_password_against_database

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -11,7 +11,14 @@ module ActsAsAuthenticTest
     end
 
     def test_login_after_create
-      assert User.create(:login => "awesome", :password => "saweeeet", :password_confirmation => "saweeeet", :email => "awesome@awesome.com")
+      assert(
+        User.create(
+          :login => "awesome",
+          :password => "saweeeet",
+          :password_confirmation => "saweeeet",
+          :email => "awesome@awesome.com"
+        )
+      )
       assert UserSession.find
     end
 

--- a/test/session_test/session_test.rb
+++ b/test/session_test/session_test.rb
@@ -24,7 +24,9 @@ module SessionTest
       def test_persist_persist_by_session_with_session_fixation_attack
         ben = users(:ben)
         controller.session["user_credentials"] = 'neo'
-        controller.session["user_credentials_id"] = { :select => " *,'neo' AS persistence_token FROM users WHERE id = #{ben.id} limit 1 -- " }
+        controller.session["user_credentials_id"] = {
+          :select => " *,'neo' AS persistence_token FROM users WHERE id = #{ben.id} limit 1 -- "
+        }
         @user_session = UserSession.find
         assert @user_session.blank?
       end


### PR DESCRIPTION
The ruby style guide recommends a line length of 80, but that is quite strict. I go for 80 in new projects, but on existing projects I typically go for 100. This project has some extremely long method names, like `merge_validates_length_of_password_field_options`, so 100 may be too ambitious.