### PR TITLE
Drop support for ruby 1.9.3

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,6 +40,9 @@ Lint/ShadowingOuterLocalVariable:
     - 'lib/authlogic/session/cookies.rb'
     - 'lib/authlogic/session/password.rb'
 
+Lint/UnneededSplatExpansion:
+  Enabled: false
+
 # Cop supports --auto-correct.
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
 Lint/UnusedBlockArgument:
@@ -250,6 +253,9 @@ Style/Lambda:
   Exclude:
     - 'lib/authlogic/acts_as_authentic/logged_in_status.rb'
 
+Style/MethodMissing:
+  Enabled: false
+
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: module_function, extend_self
 Style/ModuleFunction:
@@ -300,6 +306,9 @@ Style/Next:
 Style/Not:
   Exclude:
     - 'lib/authlogic/acts_as_authentic/login.rb'
+
+Style/NumericPredicate:
+  Enabled: false
 
 # Cop supports --auto-correct.
 Style/ParallelAssignment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
   - gem update bundler
 
 rvm:
-  - 1.9.3
   - 2.1.9
   - 2.2.5
   - 2.3.1
@@ -24,10 +23,6 @@ gemfile:
 
 matrix:
   exclude:
-    - rvm: 1.9.3
-      gemfile: test/gemfiles/Gemfile.rails-4.1.x
-    - rvm: 1.9.3
-      gemfile: test/gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.1.9
       gemfile: test/gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## Unreleased
+## 4.0.0 Unreleased
 
-* ensure that login field validation uses correct locale (@sskirby)
+* Breaking Changes
+  * Drop support for ruby 1.9.3 
+
+# Fixed
+  * ensure that login field validation uses correct locale (@sskirby)
 
 ## 3.5.0 2016-08-29
 

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
@@ -10,9 +9,9 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/binarylogic/authlogic"
   s.summary     = 'A clean, simple, and unobtrusive ruby authentication solution.'
   s.description = 'A clean, simple, and unobtrusive ruby authentication solution.'
-
   s.license = 'MIT'
 
+  s.required_ruby_version = '>= 2.0.0'
   s.add_dependency 'activerecord', ['>= 3.2', '< 5.1']
   s.add_dependency 'activesupport', ['>= 3.2', '< 5.1']
   s.add_dependency 'request_store', '~> 1.0'

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'
   s.add_development_dependency 'timecop', '~> 0.7'
-  s.add_development_dependency 'rubocop', '~> 0.41.2'
+  s.add_development_dependency 'rubocop', '~> 0.43.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/authlogic/config.rb
+++ b/lib/authlogic/config.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Authlogic
   module Config
     def self.extended(klass)

--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module Authlogic
   # This is a module the contains regular expressions used throughout Authlogic. The point of extracting
   # them out into their own module is to make them easily available to you for other uses. Ex:

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require 'test_helper'
 
 module ActsAsAuthenticTest


### PR DESCRIPTION
According to the [2016 Rails Hosting Survey](http://rails-hosting.com/2016/index.html), usage of ruby 1.9.3 has dropped to around 10%, with much of this drop occuring in 2016.

> Usage of 1.9.3 dropped by 16% [since the 2015 survey] and adoption of Ruby 2.2 and 2.3 jumped up to 27% each.

The 2016 survey had 1,417 respondents.

IMO, it is acceptable for development of a new major version of authlogic, version 4, to continue, while the 10% of the community using 1.9.3 continues to use authlogic 3.

Semver does not specify how to treat this change, and there is no consensus that I'm aware of in the ruby community. I recommend a major version bump. Version numbers are free, after all.