### PR TITLE
Fix fixture example in testing docs

### DIFF
--- a/lib/authlogic/test_case.rb
+++ b/lib/authlogic/test_case.rb
@@ -50,7 +50,7 @@ module Authlogic
   #   ben:
   #     email: whatever@whatever.com
   #     password_salt: <%= salt = Authlogic::Random.hex_token %>
-  #     crypted_password: <%= Authlogic::CryptoProviders::Sha512.encrypt("benrocks" + salt) %>
+  #     crypted_password: <%= Authlogic::CryptoProviders::SCrypt.encrypt("benrocks" + salt) %>
   #     persistence_token: <%= Authlogic::Random.hex_token %>
   #     single_access_token: <%= Authlogic::Random.friendly_token %>
   #     perishable_token: <%= Authlogic::Random.friendly_token %>


### PR DESCRIPTION
Since 3.4.0, the default crypto_provider is SCrypt. The fixture example in the docs is configured with Sha512.

This will make fail any attempt to save the UserSession in test. In particular for rails 5, the login trick (https://github.com/rails/rails/issues/23386#issuecomment-192954569) will fail.