### PR TITLE
Splitting maitain_sessions config into 2 options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Breaking Changes
   * Drop support for ruby 1.9.3
   * HTTP Basic Auth is now disabled by default (use allow_http_basic_auth to enable)
+  * maintain_sessions config has been removed. It has been split into 2 new options: log_in_after_create & log_in_after_password_change (@lucasminissale)
 
 # Fixed
   * ensure that login field validation uses correct locale (@sskirby)

--- a/README.md
+++ b/README.md
@@ -74,13 +74,31 @@ You may validate international email addresses by enabling the provided alternat
 c.validates_format_of_email_field_options = {:with => Authlogic::Regex.email_nonascii}
 ```
 
-Also, sessions are automatically maintained. You can switch this on and off with configuration, but the following will automatically log a user in after a successful registration:
+Also, sessions are automatically maintained. The following will automatically log a user in after a successful registration:
 
 ``` ruby
 User.create(params[:user])
 ```
 
-This also updates the session when the user changes his/her password.
+You can switch this on and off with the following configuration:
+
+```ruby
+class User < ActiveRecord::Base
+  acts_as_authentic do |c|
+    c.log_in_after_create = false
+  end # the configuration block is optional
+end
+```
+
+Authlogic also updates the session when the user changes his/her password. You can also switch this on and off with the following configuration:
+
+```ruby
+class User < ActiveRecord::Base
+  acts_as_authentic do |c|
+    c.log_in_after_password_change = false
+  end # the configuration block is optional
+end
+```
 
 Authlogic is very flexible, it has a strong public API and a plethora of hooks to allow you to modify behavior and extend it. Check out the helpful links below to dig deeper.
 

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -30,25 +30,25 @@ module Authlogic
       end
 
       module Config
-        # In order to turn off automatic maintenance of sessions when creating
-        # a new user, just set this to false.
+        # In order to turn off automatic maintenance of sessions
+        # after create, just set this to false.
         #
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
-        def automatically_log_in_new_user(value = nil)
-          rw_config(:automatically_log_in_new_user, value, true)
+        def log_in_after_create(value = nil)
+          rw_config(:log_in_after_create, value, true)
         end
-        alias_method :automatically_log_in_new_user=, :automatically_log_in_new_user
+        alias_method :log_in_after_create=, :log_in_after_create
 
         # In order to turn off automatic maintenance of sessions when updating
         # the password, just set this to false.
         #
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
-        def update_session_with_password_change(value = nil)
-          rw_config(:update_session_with_password_change, value, true)
+        def log_in_after_password_change(value = nil)
+          rw_config(:log_in_after_password_change, value, true)
         end
-        alias_method :update_session_with_password_change=, :update_session_with_password_change
+        alias_method :log_in_after_password_change=, :log_in_after_password_change
 
         # As you may know, authlogic sessions can be separate by id (See
         # Authlogic::Session::Base#id). You can specify here what session ids
@@ -110,7 +110,7 @@ module Authlogic
           end
 
           def maintain_session?
-            automatically_log_in_new_user? || update_session_with_password_change?
+            log_in_after_create? || log_in_after_password_change?
           end
 
           def get_session_information
@@ -161,13 +161,12 @@ module Authlogic
             self.class.session_class
           end
 
-          def automatically_log_in_new_user?
-            new_record? && self.class.automatically_log_in_new_user
+          def log_in_after_create?
+            new_record? && self.class.log_in_after_create
           end
 
-          def update_session_with_password_change?
-            persistence_token_changed? &&
-            self.class.update_session_with_password_change
+          def log_in_after_password_change?
+            persistence_token_changed? && self.class.log_in_after_password_change
           end
       end
     end

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -106,7 +106,7 @@ module Authlogic
               session_class.activated? &&
               maintain_session? &&
               !session_ids.blank? &&
-              persistence_token_changed? &&
+              persistence_token_changed?
           end
 
           def maintain_session?

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -104,8 +104,8 @@ module Authlogic
             !skip_session_maintenance &&
               session_class &&
               session_class.activated? &&
-              !session_ids.blank? &&
               maintain_session? &&
+              !session_ids.blank? &&
               persistence_token_changed? &&
           end
 

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -105,19 +105,16 @@ module Authlogic
               session_class &&
               session_class.activated? &&
               !session_ids.blank? &&
+              maintain_session? &&
               persistence_token_changed? &&
-              maintain_session_on_action?
           end
 
-          def maintain_session_on_action?
+          def maintain_session?
             # This method will return true or false depending on the action that
             # is being executed (password change or new user) and the authlogic
             # configuration.
             #
-            # action: create_new_user
-            new_record? && self.class.automatically_log_in_new_user ||
-            # action: password_change
-            persistence_token_changed? && self.class.update_session_with_password_change
+            automatically_log_in_new_user? || update_session_with_password_change?
           end
 
           def get_session_information
@@ -166,6 +163,15 @@ module Authlogic
 
           def session_class
             self.class.session_class
+          end
+
+          def automatically_log_in_new_user?
+            new_record? && self.class.automatically_log_in_new_user
+          end
+
+          def update_session_with_password_change?
+            persistence_token_changed? &&
+            self.class.update_session_with_password_change
           end
       end
     end

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -110,10 +110,6 @@ module Authlogic
           end
 
           def maintain_session?
-            # This method will return true or false depending on the action that
-            # is being executed (password change or new user) and the authlogic
-            # configuration.
-            #
             automatically_log_in_new_user? || update_session_with_password_change?
           end
 

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -2,24 +2,29 @@ require 'test_helper'
 
 module ActsAsAuthenticTest
   class SessionMaintenanceTest < ActiveSupport::TestCase
+    def setup
+      User.log_in_after_create = true
+      User.log_in_after_password_change = true
+    end
+
     def test_log_in_after_create_config
       assert User.log_in_after_create
-      setup_config(false, false)
+      User.log_in_after_create = false
       refute User.log_in_after_create
-      setup_config(true, false)
+      User.log_in_after_create = true
       assert User.log_in_after_create
     end
 
     def test_log_in_after_password_change_config
       assert User.log_in_after_password_change
-      setup_config(false, false)
+      User.log_in_after_password_change = false
       refute User.log_in_after_password_change
-      setup_config(false, true)
+      User.log_in_after_password_change = true
       assert User.log_in_after_password_change
     end
 
     def test_login_after_create
-      setup_config(true)
+      User.log_in_after_create = true
       user = User.create(
         :login => "awesome",
         :password => "saweeeet",
@@ -39,7 +44,7 @@ module ActsAsAuthenticTest
         :password_confirmation => "saweeeet",
         :email => "awesome@awesome.com"
       )
-      setup_config(false)
+      User.log_in_after_create = false
       user2 = User.create(
         :login => "awesome2",
         :password => "saweeeet2",
@@ -61,7 +66,7 @@ module ActsAsAuthenticTest
     end
 
     def test_update_session_after_password_modify
-      setup_config(false, true)
+      User.log_in_after_password_change = true
       ben = users(:ben)
       UserSession.create(ben)
       old_session_key = controller.session["user_credentials"]
@@ -76,7 +81,7 @@ module ActsAsAuthenticTest
     end
 
     def test_no_update_session_after_password_modify
-      setup_config(true, false)
+      User.log_in_after_password_change = false
       ben = users(:ben)
       UserSession.create(ben)
       old_session_key = controller.session["user_credentials"]
@@ -138,15 +143,6 @@ module ActsAsAuthenticTest
       assert ben.save
       assert UserSession.find
       assert_equal ben, UserSession.find.record
-    end
-
-    private
-
-    # This method makes sure that the config is always correct
-    # before each test
-    def setup_config(after_create = true, after_password_change = true)
-      User.log_in_after_create = after_create
-      User.log_in_after_password_change = after_password_change
     end
   end
 end

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -2,24 +2,24 @@ require 'test_helper'
 
 module ActsAsAuthenticTest
   class SessionMaintenanceTest < ActiveSupport::TestCase
-    def test_automatically_log_in_new_users_config
-      assert User.automatically_log_in_new_user
-      User.automatically_log_in_new_user = false
-      refute User.automatically_log_in_new_user
-      User.automatically_log_in_new_user = true
-      assert User.automatically_log_in_new_user
+    def test_log_in_after_create_config
+      assert User.log_in_after_create
+      setup_config(false, false)
+      refute User.log_in_after_create
+      setup_config(true, false)
+      assert User.log_in_after_create
     end
 
-    def test_update_session_with_password_change_config
-      assert User.update_session_with_password_change
-      User.update_session_with_password_change = false
-      refute User.update_session_with_password_change
-      User.update_session_with_password_change = true
-      assert User.update_session_with_password_change
+    def test_log_in_after_password_change_config
+      assert User.log_in_after_password_change
+      setup_config(false, false)
+      refute User.log_in_after_password_change
+      setup_config(false, true)
+      assert User.log_in_after_password_change
     end
 
     def test_login_after_create
-      User.automatically_log_in_new_user = true
+      setup_config(true)
       user = User.create(
         :login => "awesome",
         :password => "saweeeet",
@@ -39,7 +39,7 @@ module ActsAsAuthenticTest
         :password_confirmation => "saweeeet",
         :email => "awesome@awesome.com"
       )
-      User.automatically_log_in_new_user = false
+      setup_config(false)
       user2 = User.create(
         :login => "awesome2",
         :password => "saweeeet2",
@@ -61,7 +61,7 @@ module ActsAsAuthenticTest
     end
 
     def test_update_session_after_password_modify
-      User.update_session_with_password_change = true
+      setup_config(false, true)
       ben = users(:ben)
       UserSession.create(ben)
       old_session_key = controller.session["user_credentials"]
@@ -76,7 +76,7 @@ module ActsAsAuthenticTest
     end
 
     def test_no_update_session_after_password_modify
-      User.update_session_with_password_change = false
+      setup_config(true, false)
       ben = users(:ben)
       UserSession.create(ben)
       old_session_key = controller.session["user_credentials"]
@@ -138,6 +138,15 @@ module ActsAsAuthenticTest
       assert ben.save
       assert UserSession.find
       assert_equal ben, UserSession.find.record
+    end
+
+    private
+
+    # This method makes sure that the config is always correct
+    # before each test
+    def setup_config(after_create = true, after_password_change = true)
+      User.log_in_after_create = after_create
+      User.log_in_after_password_change = after_password_change
     end
   end
 end

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -2,12 +2,20 @@ require 'test_helper'
 
 module ActsAsAuthenticTest
   class SessionMaintenanceTest < ActiveSupport::TestCase
-    def test_maintain_sessions_config
-      assert User.maintain_sessions
-      User.maintain_sessions = false
-      refute User.maintain_sessions
-      User.maintain_sessions true
-      assert User.maintain_sessions
+    def test_automatically_log_in_new_users_config
+      assert User.automatically_log_in_new_user
+      User.automatically_log_in_new_user = false
+      refute User.automatically_log_in_new_user
+      User.automatically_log_in_new_user true
+      assert User.automatically_log_in_new_user
+    end
+
+    def test_update_session_with_password_change_config
+      assert User.update_session_with_password_change
+      User.update_session_with_password_change = false
+      refute User.update_session_with_password_change
+      User.update_session_with_password_change true
+      assert User.update_session_with_password_change
     end
 
     def test_login_after_create

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -19,6 +19,8 @@ module ActsAsAuthenticTest
     end
 
     def test_login_after_create
+      # it should autenticate the new user
+      User.automatically_log_in_new_user true
       user = User.create(
         :login => "awesome",
         :password => "saweeeet",
@@ -27,6 +29,21 @@ module ActsAsAuthenticTest
       )
       assert user.persisted?
       assert UserSession.find
+      logged_in_user = UserSession.find.user
+      assert logged_in_user == user
+
+      # it should not autenticate the new user
+      User.automatically_log_in_new_user false
+      user2 = User.create(
+        :login => "awesome2",
+        :password => "saweeeet2",
+        :password_confirmation => "saweeeet2",
+        :email => "awesome2@awesome.com"
+      )
+      assert user.persisted?
+      logged_in_user = UserSession.find.user
+      refute logged_in_user == user2
+      assert logged_in_user == user
     end
 
     def test_updating_session_with_failed_magic_state


### PR DESCRIPTION
Split the config option into two as per discussed in [522](https://github.com/binarylogic/authlogic/issues/522) - one for keeping the authentication on password update and another one for automatically log in a new user on creation.

```
acts_as_authentic do |c| 
   # c.maintain_sessions = true 
   c.automatically_log_in_new_user = true 
   c.update_session_with_password_change = true 
end 

```