### PR TITLE
Enable httponly and secure cookies by default now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Breaking Changes
   * Drop support for ruby 1.9.3
   * HTTP Basic Auth is now disabled by default (use allow_http_basic_auth to enable)
+  * 'httponly' and 'secure' cookie options are enabled by default now
 
 # Fixed
   * ensure that login field validation uses correct locale (@sskirby)

--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -54,20 +54,20 @@ module Authlogic
         # Should the cookie be set as secure?  If true, the cookie will only be sent over
         # SSL connections
         #
-        # * <tt>Default:</tt> false
+        # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
         def secure(value = nil)
-          rw_config(:secure, value, false)
+          rw_config(:secure, value, true)
         end
         alias_method :secure=, :secure
 
         # Should the cookie be set as httponly?  If true, the cookie will not be
         # accessible from javascript
         #
-        # * <tt>Default:</tt> false
+        # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
         def httponly(value = nil)
-          rw_config(:httponly, value, false)
+          rw_config(:httponly, value, true)
         end
         alias_method :httponly=, :httponly
 
@@ -227,16 +227,16 @@ module Authlogic
           def generate_cookie_for_saving
             remember_me_until_value = "::#{remember_me_until.iso8601}" if remember_me?
             {
-              :value => "#{record.persistence_token}::#{record.send(record.class.primary_key)}#{remember_me_until_value}",
-              :expires => remember_me_until,
-              :secure => secure,
-              :httponly => httponly,
-              :domain => controller.cookie_domain
+              value: "#{record.persistence_token}::#{record.send(record.class.primary_key)}#{remember_me_until_value}",
+              expires: remember_me_until,
+              secure: secure,
+              httponly: httponly,
+              domain: controller.cookie_domain
             }
           end
 
           def destroy_cookie
-            controller.cookies.delete cookie_key, :domain => controller.cookie_domain
+            controller.cookies.delete cookie_key, domain: controller.cookie_domain
           end
       end
     end

--- a/test/session_test/cookies_test.rb
+++ b/test/session_test/cookies_test.rb
@@ -43,7 +43,6 @@ module SessionTest
       end
 
       def test_secure
-        UserSession.secure = true
         assert_equal true, UserSession.secure
         session = UserSession.new
         assert_equal true, session.secure
@@ -55,7 +54,6 @@ module SessionTest
       end
 
       def test_httponly
-        UserSession.httponly = true
         assert_equal true, UserSession.httponly
         session = UserSession.new
         assert_equal true, session.httponly


### PR DESCRIPTION
Re:  this discussion: https://github.com/binarylogic/authlogic/pull/524#issuecomment-261812813

I think it's time to set `httponly` and `secure` to `true` by default on Authlogic's remember-me cookie. 

* `secure` will ensure that the remember-me cookie is always sent while encrypted
* `httponly` will ensure that XSS attacks do not have access to the remember-me cookie