### PR TITLE
Add respond_to? alongside method_missing in the adapter classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 # Fixed
   * ensure that login field validation uses correct locale (@sskirby)
+  * add a respond_to_missing? in AbstractAdapter that also checks controller respond_to?
 
 ## 3.5.0 2016-08-29
 

--- a/lib/authlogic/controller_adapters/abstract_adapter.rb
+++ b/lib/authlogic/controller_adapters/abstract_adapter.rb
@@ -58,6 +58,10 @@ module Authlogic
         controller.send(:last_request_update_allowed?)
       end
 
+      def respond_to_missing?(*args)
+        super(*args) || controller.respond_to?(*args)
+      end
+
       private
 
         def method_missing(id, *args, &block)

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module Authlogic
+  module ControllerAdapters
+    class AbstractAdapterTest < ActiveSupport::TestCase
+      def test_controller
+        controller = Class.new(MockController) do
+          def controller.an_arbitrary_method
+            'bar'
+          end
+        end.new
+        adapter = Authlogic::ControllerAdapters::AbstractAdapter.new(controller)
+
+        assert_equal controller, adapter.controller
+        assert controller.params.equal?(adapter.params)
+        assert adapter.respond_to?(:an_arbitrary_method)
+        assert_equal 'bar', adapter.an_arbitrary_method
+      end
+    end
+  end
+end


### PR DESCRIPTION
Authlogic's `controller` variable is [actually a RailsAdapter](https://github.com/binarylogic/authlogic/blob/master/lib/authlogic/controller_adapters/rails_adapter.rb#L57-L59) that proxies methods to the underlying controller.

Since the adapter has a `method_missing` that proxies anything to the controller, we should also make sure ~~`respond_to?`~~ `respond_to_missing?` is here too.

Example: someone could extend Authlogic and check `controller.respond_to?(:foo)`, and it would incorrectly return `false`, whilst they're still able to call `controller.foo` just fine. 