### PR TITLE
✂️ Remove unreachable code in authlogic/random

### DIFF
--- a/lib/authlogic/acts_as_authentic/perishable_token.rb
+++ b/lib/authlogic/acts_as_authentic/perishable_token.rb
@@ -1,13 +1,15 @@
 module Authlogic
   module ActsAsAuthentic
-    # This provides a handy token that is "perishable". Meaning the token is
-    # only good for a certain amount of time. This is perfect for resetting
-    # password, confirming accounts, etc. Typically during these actions you
-    # send them this token in via their email. Once they use the token and do
-    # what they need to do, that token should expire. Don't worry about
-    # maintaining this, changing it, or expiring it yourself. Authlogic does all
-    # of this for you. See the sub modules for all of the tools Authlogic
-    # provides to you.
+    # This provides a handy token that is "perishable", meaning the token is
+    # only good for a certain amount of time.
+    #
+    # This is useful for resetting password, confirming accounts, etc. Typically
+    # during these actions you send them this token in an email. Once they use
+    # the token and do what they need to do, that token should expire.
+    #
+    # Don't worry about maintaining the token, changing it, or expiring it
+    # yourself. Authlogic does all of this for you. See the sub modules for all
+    # of the tools Authlogic provides to you.
     module PerishableToken
       def self.included(klass)
         klass.class_eval do
@@ -16,7 +18,7 @@ module Authlogic
         end
       end
 
-      # Change how the perishable token works.
+      # Configure the perishable token.
       module Config
         # When using the find_using_perishable_token method the token can
         # expire. If the token is expired, no record will be returned. Use this
@@ -30,9 +32,8 @@ module Authlogic
         alias_method :perishable_token_valid_for=, :perishable_token_valid_for
 
         # Authlogic tries to expire and change the perishable token as much as
-        # possible, without compromising it's purpose. This is for security
-        # reasons. If you want to manage it yourself, you can stop Authlogic
-        # from getting your in way by setting this to true.
+        # possible, without compromising its purpose. If you want to manage it
+        # yourself, set this to true.
         #
         # * <tt>Default:</tt> false
         # * <tt>Accepts:</tt> Boolean
@@ -56,7 +57,7 @@ module Authlogic
           end
         end
 
-        # Class level methods for the perishable token
+        # Class methods for the perishable token
         module ClassMethods
           # Use this method to find a record with a perishable token. This
           # method does 2 things for you:

--- a/lib/authlogic/random.rb
+++ b/lib/authlogic/random.rb
@@ -1,34 +1,17 @@
+require "securerandom"
+
 module Authlogic
-  # Handles generating random strings. If SecureRandom is installed it will default to
-  # this and use it instead. SecureRandom comes with ActiveSupport. So if you are using
-  # this in a rails app you should have this library.
+  # Generates random strings using ruby's SecureRandom library.
   module Random
     extend self
 
-    SecureRandom = (defined?(::SecureRandom) && ::SecureRandom) ||
-      (defined?(::ActiveSupport::SecureRandom) && ::ActiveSupport::SecureRandom)
+    def hex_token
+      SecureRandom.hex(64)
+    end
 
-    if SecureRandom
-      def hex_token
-        SecureRandom.hex(64)
-      end
-
-      def friendly_token
-        # use base64url as defined by RFC4648
-        SecureRandom.base64(15).tr('+/=', '').strip.delete("\n")
-      end
-    else
-      def hex_token
-        Authlogic::CryptoProviders::Sha512.encrypt(Time.now.to_s + (1..10).collect { rand.to_s }.join)
-      end
-
-      FRIENDLY_CHARS = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
-
-      def friendly_token
-        newpass = ""
-        1.upto(20) { newpass << FRIENDLY_CHARS[rand(FRIENDLY_CHARS.size - 1)] }
-        newpass
-      end
+    def friendly_token
+      # use base64url as defined by RFC4648
+      SecureRandom.base64(15).tr('+/=', '').strip.delete("\n")
     end
   end
 end

--- a/test/random_test.rb
+++ b/test/random_test.rb
@@ -1,46 +1,13 @@
 require 'test_helper'
 
 class RandomTest < ActiveSupport::TestCase
-  def test_random_tokens_are_indeed_random
-    # this might fail if you are *really* unlucky :)
-    with_any_random do
-      assert_not_equal Authlogic::Random.hex_token,       Authlogic::Random.hex_token
-      assert_not_equal Authlogic::Random.friendly_token,  Authlogic::Random.friendly_token
-    end
+  def test_that_hex_tokens_are_unique
+    tokens = Array.new(100) { Authlogic::Random.hex_token }
+    assert_equal tokens.size, tokens.uniq.size
   end
 
-  private
-
-    def with_any_random(&block)
-      [true, false].each { |val| with_secure_random_enabled(val, &block) }
-    end
-
-    def with_secure_random_enabled(enabled = true)
-      # can't really test SecureRandom if we don't have an implementation
-      return if enabled && !Authlogic::Random::SecureRandom
-
-      current_sec_rand = Authlogic::Random::SecureRandom
-      reload_authlogic_with_sec_random!(current_sec_rand, enabled)
-
-      yield
-    ensure
-      reload_authlogic_with_sec_random!(current_sec_rand)
-    end
-
-    def reload_authlogic_with_sec_random!(secure_random, enabled = true)
-      silence_warnings do
-        secure_random.parent.const_set(
-          secure_random.name.sub("#{secure_random.parent}::", ''),
-          enabled ? secure_random : nil
-        )
-        load(File.dirname(__FILE__) + '/../lib/authlogic/random.rb')
-      end
-    end
-
-    def silence_warnings
-      old_verbose, $VERBOSE = $VERBOSE, nil
-      yield
-    ensure
-      $VERBOSE = old_verbose
-    end
+  def test_that_friendly_tokens_are_unique
+    tokens = Array.new(100) { Authlogic::Random.friendly_token }
+    assert_equal tokens.size, tokens.uniq.size
+  end
 end


### PR DESCRIPTION
Authlogic only supports rails >= 3.2 and ruby >= 2.1. Under those conditions, ruby's securerandom library is always available and rails' defunct securerandom library is never available. The latter was removed in rails 3.1.

