### PR TITLE
Conform Random.friendly_token to RFC-4648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
     log_in_after_create & log_in_after_password_change (@lucasminissale)
 
 * Fixed
+  * Random.friendly_token (used for e.g. perishable token) now returns strings
+    of consistent length, and conforms better to RFC-4648
   * ensure that login field validation uses correct locale (@sskirby)
   * add a respond_to_missing? in AbstractAdapter that also checks controller respond_to?
 

--- a/lib/authlogic/random.rb
+++ b/lib/authlogic/random.rb
@@ -9,9 +9,10 @@ module Authlogic
       SecureRandom.hex(64)
     end
 
+    # Returns a string in base64url format as defined by RFC-3548 and RFC-4648.
+    # We call this a "friendly" token because it is short and safe for URLs.
     def friendly_token
-      # use base64url as defined by RFC4648
-      SecureRandom.base64(15).tr('+/=', '').strip.delete("\n")
+      SecureRandom.urlsafe_base64(15)
     end
   end
 end


### PR DESCRIPTION
It was close, now it should be conforming slightly better.

As an added bonus, now it returns strings of a consistent length.