### PR TITLE
Allow users to customize invalid session error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   * maintain_sessions config has been removed. It has been split into 2 new options: 
     log_in_after_create & log_in_after_password_change (@lucasminissale)
 
+* Added
+  * [#98](https://github.com/binarylogic/authlogic/issues/98)
+    I18n for invalid session error message. (@eugenebolshakov)
+
 * Fixed
   * ensure that login field validation uses correct locale (@sskirby)
   * add a respond_to_missing? in AbstractAdapter that also checks controller respond_to?

--- a/lib/authlogic/i18n.rb
+++ b/lib/authlogic/i18n.rb
@@ -46,6 +46,7 @@ module Authlogic
   #       not_approved: Your account is not approved
   #       no_authentication_details: You did not provide any details for authentication.
   #       general_credentials_error: Login/Password combination is not valid
+  #       session_invalid: Your session is invalid and has the following errors:
   #     models:
   #       user_session: UserSession (or whatever name you are using)
   #     attributes:

--- a/lib/authlogic/session/existence.rb
+++ b/lib/authlogic/session/existence.rb
@@ -4,7 +4,12 @@ module Authlogic
     module Existence
       class SessionInvalidError < ::StandardError # :nodoc:
         def initialize(session)
-          super("Your session is invalid and has the following errors: #{session.errors.full_messages.to_sentence}")
+          message = I18n.t(
+            'error_messages.session_invalid',
+            default: "Your session is invalid and has the following errors:"
+          )
+          message += " #{session.errors.full_messages.to_sentence}"
+          super message
         end
       end
 

--- a/test/session_test/existence_test.rb
+++ b/test/session_test/existence_test.rb
@@ -71,5 +71,16 @@ module SessionTest
         refute session.record
       end
     end
+
+    class SessionInvalidErrorTest < ActiveSupport::TestCase
+      def test_message
+        session = UserSession.new
+        assert !session.valid?
+        error = Authlogic::Session::Existence::SessionInvalidError.new(session)
+        message = "Your session is invalid and has the following errors: " +
+          session.errors.full_messages.to_sentence
+        assert_equal message, error.message
+      end
+    end
   end
 end


### PR DESCRIPTION
From https://github.com/binarylogic/authlogic/issues/98