### PR TITLE
Allow rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 
 rvm:
   - 1.9.3
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
 
 gemfile:
   - test/gemfiles/Gemfile.rails-3.2.x
@@ -21,6 +21,7 @@ gemfile:
   - test/gemfiles/Gemfile.rails-4.1.x
   - test/gemfiles/Gemfile.rails-4.2.x
   - test/gemfiles/Gemfile.rails-5.0.x
+  - test/gemfiles/Gemfile.rails-5.1.x
 
 matrix:
   exclude:
@@ -28,11 +29,15 @@ matrix:
       gemfile: test/gemfiles/Gemfile.rails-4.1.x
     - rvm: 1.9.3
       gemfile: test/gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.9
+    - rvm: 1.9.3
+      gemfile: test/gemfiles/Gemfile.rails-5.1.x
+    - rvm: 2.1.10
       gemfile: test/gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.2.5
+    - rvm: 2.1.10
+      gemfile: test/gemfiles/Gemfile.rails-5.1.x
+    - rvm: 2.2.6
       gemfile: test/gemfiles/Gemfile.rails-3.2.x
-    - rvm: 2.3.1
+    - rvm: 2.3.3
       gemfile: test/gemfiles/Gemfile.rails-3.2.x
   fast_finish: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Added
+
+* rails 5.1 support
+
+Fixed
+
 * ensure that login field validation uses correct locale (@sskirby)
 
 ## 3.5.0 2016-08-29

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.add_dependency 'activerecord', ['>= 3.2', '< 5.1']
-  s.add_dependency 'activesupport', ['>= 3.2', '< 5.1']
+  s.add_dependency 'activerecord', ['>= 3.2', '< 5.2']
+  s.add_dependency 'activesupport', ['>= 3.2', '< 5.2']
   s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'

--- a/test/gemfiles/Gemfile.rails-5.1.x
+++ b/test/gemfiles/Gemfile.rails-5.1.x
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+gemspec :path => "./../.."
+
+gem "activerecord", "~> 5.1.0"
+gem "activesupport", "~> 5.1.0"
+gem 'sqlite3', :platforms => :ruby


### PR DESCRIPTION
Backport https://github.com/binarylogic/authlogic/pull/549 to the `3-stable` branch so we can cut a 3.6.0 release.