### PR TITLE
Use Array.wrap (Oh, and btw drop rails < 4.2 😱)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ rvm:
   - 2.3.3
 
 gemfile:
-  - test/gemfiles/Gemfile.rails-3.2.x
-  - test/gemfiles/Gemfile.rails-4.0.x
-  - test/gemfiles/Gemfile.rails-4.1.x
   - test/gemfiles/Gemfile.rails-4.2.x
   - test/gemfiles/Gemfile.rails-5.0.x
   - test/gemfiles/Gemfile.rails-5.1.x
@@ -32,10 +29,6 @@ matrix:
       gemfile: test/gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.1.10
       gemfile: test/gemfiles/Gemfile.rails-5.1.x
-    - rvm: 2.2.6
-      gemfile: test/gemfiles/Gemfile.rails-3.2.x
-    - rvm: 2.3.3
-      gemfile: test/gemfiles/Gemfile.rails-3.2.x
   fast_finish: true
 
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Breaking Changes
   * Drop support for ruby 1.9.3
+  * Drop support for rails < 4.2
   * HTTP Basic Auth is now disabled by default (use allow_http_basic_auth to enable)
   * 'httponly' and 'secure' cookie options are enabled by default now
   * maintain_sessions config has been removed. It has been split into 2 new options: 

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.required_ruby_version = '>= 2.1.0'
-  s.add_dependency 'activerecord', ['>= 3.2', '< 5.2']
-  s.add_dependency 'activesupport', ['>= 3.2', '< 5.2']
+  s.add_dependency 'activerecord', ['>= 4.2', '< 5.2']
+  s.add_dependency 'activesupport', ['>= 4.2', '< 5.2']
   s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -266,7 +266,7 @@ module Authlogic
             if value.first.class.name == "ActionController::Parameters"
               [value.first.to_h]
             else
-              value.is_a?(Array) ? value : [value]
+              Array.wrap(value)
             end
           end
       end


### PR DESCRIPTION
`Array#wrap` is defined by activesupport >= 4.

Dang, I just realized we haven't decided whether to drop support for rails 3 yet. Well, I'll open a PR and we can discuss it. :)

Obviously I am not suggesting we drop rails < 4.2 just so I can use `Array.wrap`. The reason is because rails < 4.2 are EOL already.