### PR TITLE
Fix Session::Cookies#credentials= for ActionController::Parameters

### DIFF
--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -88,12 +88,20 @@ module Authlogic
         # Allows you to set the remember_me option when passing credentials.
         def credentials=(value)
           super
-          values = value.is_a?(Array) ? value : [value]
+
+          # In Rails 5 the ActionController::Parameters no longer inherits from
+          # HashWithIndifferentAccess. (http://bit.ly/2gnK08F) This method
+          # converts the ActionController::Parameters to a Hash.
+          if value.class.name == "ActionController::Parameters"
+            value = value.to_h
+          end
+
+          values = Array.wrap(value)
+
           case values.first
           when Hash
-            if values.first.with_indifferent_access.key?(:remember_me)
-              self.remember_me = values.first.with_indifferent_access[:remember_me]
-            end
+            credentials = values.first.with_indifferent_access
+            self.remember_me = credentials[:remember_me] if credentials.key?(:remember_me)
           else
             r = values.find { |val| val.is_a?(TrueClass) || val.is_a?(FalseClass) }
             self.remember_me = r if !r.nil?

--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -12,7 +12,7 @@ module Authlogic
       # Setting the id if it is passed in the credentials.
       def credentials=(value)
         super
-        values = value.is_a?(Array) ? value : [value]
+        values = Array.wrap(value)
         self.id = values.last if values.last.is_a?(Symbol)
       end
 

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -154,7 +154,15 @@ module Authlogic
         # hash form.
         def credentials=(value)
           super
-          values = parse_param_val(value) # add strong parameters check
+
+          # In Rails 5 the ActionController::Parameters no longer inherits from
+          # HashWithIndifferentAccess. (http://bit.ly/2gnK08F) This method
+          # converts the ActionController::Parameters to a Hash.
+          if value.class.name == "ActionController::Parameters"
+            value = value.to_h
+          end
+
+          values = Array.wrap(value)
 
           if values.first.is_a?(Hash)
             values.first.with_indifferent_access.slice(login_field, password_field).each do |field, val|
@@ -257,17 +265,6 @@ module Authlogic
 
           def verify_password_method
             self.class.verify_password_method
-          end
-
-          # In Rails 5 the ActionController::Parameters no longer inherits from
-          # HashWithIndifferentAccess. (http://bit.ly/2gnK08F) This method
-          # converts the ActionController::Parameters to a Hash.
-          def parse_param_val(value)
-            if value.first.class.name == "ActionController::Parameters"
-              [value.first.to_h]
-            else
-              Array.wrap(value)
-            end
           end
       end
     end

--- a/lib/authlogic/session/priority_record.rb
+++ b/lib/authlogic/session/priority_record.rb
@@ -15,7 +15,7 @@ module Authlogic
       #   session.credentials = [real_user_object, priority_user_object]
       def credentials=(value)
         super
-        values = value.is_a?(Array) ? value : [value]
+        values = Array.wrap(value)
         self.priority_record = values[1] if values[1].class < ::ActiveRecord::Base
       end
 

--- a/lib/authlogic/session/unauthorized_record.rb
+++ b/lib/authlogic/session/unauthorized_record.rb
@@ -33,7 +33,7 @@ module Authlogic
       # Setting the unauthorized record if it exists in the credentials passed.
       def credentials=(value)
         super
-        values = value.is_a?(Array) ? value : [value]
+        values = Array.wrap(value)
         self.unauthorized_record = values.first if values.first.class < ::ActiveRecord::Base
       end
 

--- a/test/gemfiles/Gemfile.rails-5.0.x
+++ b/test/gemfiles/Gemfile.rails-5.0.x
@@ -3,4 +3,5 @@ gemspec :path => "./../.."
 
 gem "activerecord", "~> 5.0.1"
 gem "activesupport", "~> 5.0.1"
+gem "actionpack", "~> 5.0.1" # to test ActionController::Parameters
 gem 'sqlite3', :platforms => :ruby

--- a/test/gemfiles/Gemfile.rails-5.1.x
+++ b/test/gemfiles/Gemfile.rails-5.1.x
@@ -3,4 +3,5 @@ gemspec :path => "./../.."
 
 gem "activerecord", "~> 5.1.0"
 gem "activesupport", "~> 5.1.0"
+gem "actionpack", "~> 5.1.0" # to test ActionController::Parameters
 gem 'sqlite3', :platforms => :ruby

--- a/test/session_test/cookies_test.rb
+++ b/test/session_test/cookies_test.rb
@@ -84,6 +84,17 @@ module SessionTest
         assert_equal true, session.remember_me
       end
 
+      if ActiveRecord.version >= Gem::Version.new("5.0")
+        require 'action_controller'
+        def test_credentials_with_actioncontroller_parameters
+          session = UserSession.new
+          session.credentials = ActionController::Parameters
+            .new(remember_me: true)
+            .permit(:remember_me)
+          assert_equal true, session.remember_me
+        end
+      end
+
       def test_remember_me
         session = UserSession.new
         assert_equal false, session.remember_me

--- a/test/session_test/password_test.rb
+++ b/test/session_test/password_test.rb
@@ -86,6 +86,18 @@ module SessionTest
         assert_equal({ :password => "<protected>", :login => "login" }, session.credentials)
       end
 
+      if ActiveRecord.version >= Gem::Version.new("5.0")
+        require 'action_controller'
+        def test_credentials_with_actioncontroller_parameters
+          session = UserSession.new
+          session.credentials = ActionController::Parameters
+            .new(login: "login", password: "pass")
+            .permit(:login, :password)
+          assert_equal "login", session.login
+          assert_equal "pass", session.send(:protected_password)
+        end
+      end
+
       def test_credentials_are_params_safe
         session = UserSession.new
         assert_nothing_raised { session.credentials = { :hacker_method => "error!" } }


### PR DESCRIPTION
# What

* adds a test and fix for `Authlogic::Session::Cookie#credentials=` to allow `ActionController::Parameters` to work with `remember_me` option.
* also backfills a test for `Authlogic::Session::Password#credentials=`'s similar fix.
* also a little refactoring/cleanup

# Why

A fix for Rails 5.0 was [added last year](https://github.com/binarylogic/authlogic/pull/488/files#diff-787b053df61ef72f7d5a6e4d0d440d2aR242) to accommodate `ActionController::Parameters` with the `credentials=` writer method.

That worked but didn't fix the case when you pass in the `:remember_me` option. This should fix up that case.

Fixes https://github.com/binarylogic/authlogic/issues/556