### PR TITLE
Allow max length of tld to 24 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
     of consistent length, and conforms better to RFC-4648
   * ensure that login field validation uses correct locale (@sskirby)
   * add a respond_to_missing? in AbstractAdapter that also checks controller respond_to?
+  * Allow tld up to 24 characters per https://data.iana.org/TLD/tlds-alpha-by-domain.txt 
 
 ## 3.6.0 2017-04-28
 

--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -14,7 +14,7 @@ module Authlogic
       @email_regex ||= begin
         email_name_regex  = '[A-Z0-9_\.&%\+\-\']+'
         domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
-        domain_tld_regex  = '(?:[A-Z]{2,13})'
+        domain_tld_regex  = '(?:[A-Z]{2,25})'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
       end
     end

--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -6,7 +6,7 @@ module Authlogic
   #   validates_format_of :my_email_field, :with => Authlogic::Regex.email
   module Regex
     # A general email regular expression. It allows top level domains (TLD) to be from 2 -
-    # 13 in length. The decisions behind this regular expression were made by analyzing
+    # 24 in length. The decisions behind this regular expression were made by analyzing
     # the list of top-level domains maintained by IANA and by reading this website:
     # http://www.regular-expressions.info/email.html, which is an excellent resource for
     # regular expressions.
@@ -37,7 +37,7 @@ module Authlogic
       @email_nonascii_regex ||= begin
         email_name_regex  = '[^[:cntrl:][@\[\]\^ \!\"#$\(\)*,/:;<=>\?`{|}~\\\]]+'
         domain_head_regex = '(?:[^[:cntrl:][@\[\]\^ \!\"#$&\(\)*,/:;<=>\?`{|}~\\\_\.%\+\']]+\.)+'
-        domain_tld_regex  = '(?:[^[:cntrl:][@\[\]\^ \!\"#$&\(\)*,/:;<=>\?`{|}~\\\_\.%\+\-\'0-9]]{2,13})'
+        domain_tld_regex  = '(?:[^[:cntrl:][@\[\]\^ \!\"#$&\(\)*,/:;<=>\?`{|}~\\\_\.%\+\-\'0-9]]{2,25})'
         /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/
       end
     end

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -7,7 +7,8 @@ module ActsAsAuthenticTest
       "damien+test1...etc..@mydomain.com",
       "dakota.dux+1@gmail.com",
       "dakota.d'ux@gmail.com",
-      "a&b@c.com"
+      "a&b@c.com",
+      "someuser@somedomain.travelersinsurance"
     ]
 
     BAD_ASCII_EMAILS = [
@@ -15,7 +16,8 @@ module ActsAsAuthenticTest
       "aaaaaaaaaaaaa",
       "question?mark@gmail.com",
       "backslash@g\\mail.com",
-      "<script>alert(123);</script>\nnobody@example.com"
+      "<script>alert(123);</script>\nnobody@example.com",
+      "someuser@somedomain.isreallytoolongandimeanreallytoolong"
     ]
 
     # http://en.wikipedia.org/wiki/ISO/IEC_8859-1#Codepage_layout


### PR DESCRIPTION
This regex would fail if a user would use a tld larger than 12 characters, for example someuser@somedomain.travelersinsurance.  As such, increasing it to 24 characters to allow the ICANN domains listed here within their master list.

https://data.iana.org/TLD/tlds-alpha-by-domain.txt
