### PR TITLE
fixed timber.io tail-user link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A clean, simple, and unobtrusive ruby authentication solution.
 
 [![Timber Logging](http://res.cloudinary.com/timber/image/upload/v1490556810/pricing/sponsorship.png)](https://timber.io?utm_source=github&utm_medium=authlogic)
 
-[Tail Authlogic users](https://timber.io/docs/app/tutorials/tail-a-user?utm_source=github&utm_medium=authlogic) in your logs!
+[Tail Authlogic users](https://timber.io/docs/app/console/tail-a-user) in your logs!
 
 ## Documentation
 


### PR DESCRIPTION
Fixes https://github.com/binarylogic/authlogic/issues/567