### PR TITLE
Drop support for ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - gem update bundler
 
 rvm:
-  - 2.1.10
+  - 2.2.8
   - 2.4.2
 
 gemfile:
@@ -20,11 +20,6 @@ gemfile:
   - test/gemfiles/Gemfile.rails-5.1.x
 
 matrix:
-  exclude:
-    - rvm: 2.1.10
-      gemfile: test/gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.10
-      gemfile: test/gemfiles/Gemfile.rails-5.1.x
   fast_finish: true
 
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.0.0 Unreleased
 
 * Breaking Changes
-  * Drop support for ruby 1.9.3
+  * Drop support for ruby < 2.2
   * Drop support for rails < 4.2
   * HTTP Basic Auth is now disabled by default (use allow_http_basic_auth to enable)
   * 'httponly' and 'secure' cookie options are enabled by default now

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A clean, simple, and unobtrusive ruby authentication solution.
 
 | Version    | branches         | tag     | ruby     | activerecord  |
 | ---------- | ---------------- | ------- | -------- | ------------- |
-| Unreleased | master, 4-stable |         | >= 2.1.0 | >= 3.2, < 5.2 |
+| Unreleased | master, 4-stable |         | >= 2.2.0 | >= 4.2, < 5.2 |
 | 3          | 3-stable         | v3.6.0  | >= 1.9.3 | >= 3.2, < 5.2 |
 | 2          | rails2           | v2.1.11 | >= 1.9.3 | ~> 2.3.0      |
 | 1          | ?                | v1.4.3  | ?        | ?             |

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = 'A clean, simple, and unobtrusive ruby authentication solution.'
   s.license = 'MIT'
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.2.0'
   s.add_dependency 'activerecord', ['>= 4.2', '< 5.2']
   s.add_dependency 'activesupport', ['>= 4.2', '< 5.2']
   s.add_dependency 'request_store', '~> 1.0'


### PR DESCRIPTION
Ruby 2.1 reached EoL on 2017-04-01
https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/