### PR TITLE
Remove special treatment for AC::Parameters

### DIFF
--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bcrypt', '~> 3.1'
   s.add_development_dependency 'timecop', '~> 0.7'
   s.add_development_dependency 'rubocop', '~> 0.41.2'
-  s.add_development_dependency 'actionpack', '>= 5.0'
+  s.add_development_dependency 'actionpack', ['>= 3.2', '< 5.2']
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bcrypt', '~> 3.1'
   s.add_development_dependency 'timecop', '~> 0.7'
   s.add_development_dependency 'rubocop', '~> 0.41.2'
+  s.add_development_dependency 'actionpack', '>= 5.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Fixes #512

In relation to #558

I've removed the special treatment for AC::Parameters and added a couple of tests to ensure it all works. As it was I don't think it ever worked because we were calling.first on the parameters, a method it doesn't support.

Anyway, the failing tests now are related to tests sending in invalid hash contents (i.e. login and password keys missing). In the past these were quietly ignored, but now we're raising an error.

I'm not sure what you want the policy to be. It'd be rude to raise an application error just because some hacker sent parameters that didn't contain the login elements, but we still need to raise an error for the case where AC::Params haven't been permitted. Perhaps we can raise the error in development only? In which case, how do we write automated tests for that?