### PR TITLE
Help AC::Parameters users by raising an error ..

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -97,7 +97,7 @@ Style/Proc:
 # Configuration parameters: SupportedStyles.
 # SupportedStyles: compact, exploded
 Style/RaiseArgs:
-  EnforcedStyle: compact
+  Enabled: false
 
 # Offense count: 3
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## 4.0.0 Unreleased
 
-* Breaking Changes
+* Breaking Changes, Major
   * Drop support for ruby < 2.2
   * Drop support for rails < 4.2
   * HTTP Basic Auth is now disabled by default (use allow_http_basic_auth to enable)
   * 'httponly' and 'secure' cookie options are enabled by default now
   * maintain_sessions config has been removed. It has been split into 2 new options:
     log_in_after_create & log_in_after_password_change (@lucasminissale)
+  * [#577](https://github.com/binarylogic/authlogic/pull/577) Password
+    authentication (eg. UserSession.new, .create) will now raise an
+    error if `login_field` or `password_field` are mising.
+
+* Breaking Changes, Minor
   * Methods in Authlogic::Random are now module methods, and are no longer
     instance methods. Previously, there were both. Do not use Authlogic::Random
     as a mixin.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,13 @@ BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-4.2.x bundle install
 BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-4.2.x bundle exec rake
 ```
 
+To run a single test:
+
+```bash
+BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-4.2.x \
+  bundle exec ruby –I test path/to/test.rb
+```
+
 ### Linting
 
 Running `rake` also runs a linter, rubocop. Contributions must pass both

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -2,6 +2,11 @@ module Authlogic
   module Session
     # Handles authenticating via a traditional username and password.
     module Password
+      E_CREDENTIAL_PARAMS_MISSING = <<-EOS.squish.freeze
+        The following parameter(s) were missing from
+        the supplied credentials: %s.
+      EOS
+
       def self.included(klass)
         klass.class_eval do
           extend Config
@@ -150,16 +155,45 @@ module Authlogic
           end
         end
 
-        # Accepts the login_field / password_field credentials combination in
-        # hash form.
+        # Accepts the login_field / password_field credentials. `value` can be
+        # any of the following:
+        #
+        # ```
+        # { :login => "my login", :password => "my password", :remember_me => true }
+        # [my_user_object, true]
+        # [{ :login => "my login", :password => "my password", :remember_me => true }, :my_id]
+        # [my_user_object, true, :my_id]
+        # [{ priority_record: my_object }, :my_id]
+        # ```
+        #
+        # See `Foundation::InstanceMethods#credentials=` for further explanation.
+        #
+        # It's common to provide an ActiveSupport::Parameters instead of a Hash.
+        # We don't officially support that, but as long as you `permit` the
+        # expected keys (login_field, password_field) it's OK.
         def credentials=(value)
           super
-          values = parse_param_val(value) # add strong parameters check
+          potential_hash = value.is_a?(Array) ? value.first : value
 
-          if values.first.is_a?(Hash)
-            values.first.with_indifferent_access.slice(login_field, password_field).each do |field, val|
-              next if val.blank?
-              send("#{field}=", val)
+          # nil is allowed only for backwards compatibility. It's not really
+          # useful to do, e.g. `UserSession.new` with no arguments in practice.
+          return if potential_hash.nil?
+
+          if potential_hash.respond_to?(:to_h)
+            hash = potential_hash.to_h.with_indifferent_access
+            if hash.key?(:priority_record)
+              # noop. We're probably doing a `UserSession.find` with no
+              # arguments. See #find in session/persistence.rb
+            else
+              required_credentials = hash.slice(*required_credential_keys)
+              missing_credentials = required_credential_keys.map(&:to_s) - required_credentials.keys.map(&:to_s)
+              unless missing_credentials.empty?
+                raise ArgumentError, format(E_CREDENTIAL_PARAMS_MISSING, missing_credentials.join(', '))
+              end
+              required_credentials.each do |field, val|
+                next if val.blank?
+                send("#{field}=", val)
+              end
             end
           end
         end
@@ -267,19 +301,12 @@ module Authlogic
             self.class.password_field
           end
 
-          def verify_password_method
-            self.class.verify_password_method
+          def required_credential_keys
+            [login_field, password_field]
           end
 
-          # In Rails 5 the ActionController::Parameters no longer inherits from
-          # HashWithIndifferentAccess. (http://bit.ly/2gnK08F) This method
-          # converts the ActionController::Parameters to a Hash.
-          def parse_param_val(value)
-            if value.first.class.name == "ActionController::Parameters"
-              [value.first.to_h]
-            else
-              Array.wrap(value)
-            end
+          def verify_password_method
+            self.class.verify_password_method
           end
       end
     end

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -2,6 +2,12 @@ module Authlogic
   module Session
     # Handles authenticating via a traditional username and password.
     module Password
+      # Raised when the provided credentails lack one or more required keys.
+      # It's OK for e.g. password to be blank, but there still must be a key
+      # matching `password_field`.
+      class CredentialKeyError < ::StandardError
+      end
+
       E_CREDENTIAL_PARAMS_MISSING = <<-EOS.squish.freeze
         The following parameter(s) were missing from
         the supplied credentials: %s.
@@ -188,7 +194,10 @@ module Authlogic
               required_credentials = hash.slice(*required_credential_keys)
               missing_credentials = required_credential_keys.map(&:to_s) - required_credentials.keys.map(&:to_s)
               unless missing_credentials.empty?
-                raise ArgumentError, format(E_CREDENTIAL_PARAMS_MISSING, missing_credentials.join(', '))
+                raise(
+                  CredentialKeyError,
+                  format(E_CREDENTIAL_PARAMS_MISSING, missing_credentials.join(', '))
+                )
               end
               required_credentials.each do |field, val|
                 next if val.blank?

--- a/test/session_test/cookies_test.rb
+++ b/test/session_test/cookies_test.rb
@@ -80,7 +80,11 @@ module SessionTest
     class InstanceMethodsTest < ActiveSupport::TestCase
       def test_credentials
         session = UserSession.new
-        session.credentials = { remember_me: true }
+        session.credentials = {
+          login: 'foo',
+          password: 'bar',
+          remember_me: true
+        }
         assert_equal true, session.remember_me
       end
 

--- a/test/session_test/password_test.rb
+++ b/test/session_test/password_test.rb
@@ -89,7 +89,7 @@ module SessionTest
       def test_non_permitted_action_controller_parameters_credentials
         session = UserSession.new
         invalid_credentials = { login: 'login' } # missing key: password
-        e = assert_raises(ArgumentError) do
+        e = assert_raises(::Authlogic::Session::Password::CredentialKeyError) do
           session.credentials = invalid_credentials
         end
         assert_equal(
@@ -103,7 +103,7 @@ module SessionTest
       # not occur. Perhaps use a `Minitest::Mock`?
       def test_credentials_are_params_safe
         session = UserSession.new
-        e = assert_raises(ArgumentError) do
+        e = assert_raises(::Authlogic::Session::Password::CredentialKeyError) do
           session.credentials = { hacker_method: "error!" }
         end
         assert_equal(

--- a/test/session_test/password_test.rb
+++ b/test/session_test/password_test.rb
@@ -86,9 +86,21 @@ module SessionTest
         assert_equal({ password: "<protected>", login: "login" }, session.credentials)
       end
 
+      def test_non_permitted_action_controller_parameters_credentials
+        session = UserSession.new
+        invalid_credentials = { login: 'login' } # missing key: password
+        expected_error_message = 'The following parameter(s) were missing ' \
+          'from the supplied credentials: password'
+        assert_raise(ArgumentError, expected_error_message) do
+          session.credentials = invalid_credentials
+        end
+      end
+
       def test_credentials_are_params_safe
         session = UserSession.new
-        assert_nothing_raised { session.credentials = { hacker_method: "error!" } }
+        assert_raise(ArgumentError) do
+          session.credentials = { hacker_method: "error!" }
+        end
       end
 
       def test_save_with_credentials

--- a/test/session_test/password_test.rb
+++ b/test/session_test/password_test.rb
@@ -89,18 +89,28 @@ module SessionTest
       def test_non_permitted_action_controller_parameters_credentials
         session = UserSession.new
         invalid_credentials = { login: 'login' } # missing key: password
-        expected_error_message = 'The following parameter(s) were missing ' \
-          'from the supplied credentials: password'
-        assert_raise(ArgumentError, expected_error_message) do
+        e = assert_raises(ArgumentError) do
           session.credentials = invalid_credentials
         end
+        assert_equal(
+          'The following parameter(s) were missing ' \
+          'from the supplied credentials: password.',
+          e.message
+        )
       end
 
+      # TODO: Do a better job of demonstrating that `send(:hacker_method)` does
+      # not occur. Perhaps use a `Minitest::Mock`?
       def test_credentials_are_params_safe
         session = UserSession.new
-        assert_raise(ArgumentError) do
+        e = assert_raises(ArgumentError) do
           session.credentials = { hacker_method: "error!" }
         end
+        assert_equal(
+          'The following parameter(s) were missing ' \
+          'from the supplied credentials: login, password.',
+          e.message
+        )
       end
 
       def test_save_with_credentials


### PR DESCRIPTION
.. when they forget to `permit`.

**Please don't merge this, needs discussion**

In authlogic 4, we had planned to simply require a plain Hash, but @brendon suggested that we continue to call `to_h` and only raise if the two required keys are missing. Brendon's suggestion is possible, as I show here, but it is messy because there are so many possible arguments to `credentials=`.
