### PR TITLE
Allows support for Rails 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ gemfile:
   - test/gemfiles/Gemfile.rails-4.2.x
   - test/gemfiles/Gemfile.rails-5.0.x
   - test/gemfiles/Gemfile.rails-5.1.x
+  - test/gemfiles/Gemfile.rails-5.2.x
 
 matrix:
   fast_finish: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   * Our mutable constants (e.g. arrays, hashes) are now frozen.
 
 * Added
+  * Support for rails 5.2
   * Support for ruby 2.4, specifically openssl gem 2.0
   * [#98](https://github.com/binarylogic/authlogic/issues/98)
     I18n for invalid session error message. (@eugenebolshakov)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A clean, simple, and unobtrusive ruby authentication solution.
 
 | Version    | branches         | tag     | ruby     | activerecord  |
 | ---------- | ---------------- | ------- | -------- | ------------- |
-| Unreleased | master, 4-stable |         | >= 2.2.0 | >= 4.2, < 5.2 |
+| Unreleased | master, 4-stable |         | >= 2.2.0 | >= 4.2, < 5.3 |
 | 3          | 3-stable         | v3.6.0  | >= 1.9.3 | >= 3.2, < 5.2 |
 | 2          | rails2           | v2.1.11 | >= 1.9.3 | ~> 2.3.0      |
 | 1          | ?                | v1.4.3  | ?        | ?             |

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.required_ruby_version = '>= 2.2.0'
-  s.add_dependency 'activerecord', ['>= 4.2', '< 5.2']
-  s.add_dependency 'activesupport', ['>= 4.2', '< 5.2']
+  s.add_dependency 'activerecord', ['>= 4.2', '< 5.3']
+  s.add_dependency 'activesupport', ['>= 4.2', '< 5.3']
   s.add_dependency 'request_store', '~> 1.0'
   s.add_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'

--- a/test/gemfiles/Gemfile.rails-5.2.x
+++ b/test/gemfiles/Gemfile.rails-5.2.x
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+gemspec :path => "./../.."
+
+gem "activerecord", "~> 5.2.x"
+gem "activesupport", "~> 5.2.x"
+gem 'sqlite3', :platforms => :ruby


### PR DESCRIPTION
This PR relieves restrictions on activesupport and activerecord versions. As requested by @jaredbeck this PR targets master instead of `stable-3`.

