### PR TITLE
Prepare for release 3.8.0

### DIFF
--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -1,3 +1,9 @@
+# Authlogic uses ActiveSupport's core extensions like `strip_heredoc`, which
+# ActiveRecord does not `require`. It's possible that we could save a few
+# milliseconds by loading only the specific core extensions we need, but
+# `all.rb` is simpler. We can revisit this decision if it becomes a problem.
+require "active_support/all"
+
 require "active_record"
 
 path = File.dirname(__FILE__) + "/authlogic/"

--- a/lib/authlogic/crypto_providers/aes256.rb
+++ b/lib/authlogic/crypto_providers/aes256.rb
@@ -38,8 +38,27 @@ module Authlogic
         private
 
           def aes
-            raise ArgumentError.new("You must provide a key like #{name}.key = my_key before using the #{name}") if @key.blank?
-            @aes ||= OpenSSL::Cipher::Cipher.new("AES-256-ECB")
+            if @key.blank?
+              raise ArgumentError.new(
+                "You must provide a key like #{name}.key = my_key before using the #{name}"
+              )
+            end
+
+            @aes ||= openssl_cipher_class.new("AES-256-ECB")
+          end
+
+          # `::OpenSSL::Cipher::Cipher` has been deprecated since at least 2014,
+          # in favor of `::OpenSSL::Cipher`, but a deprecation warning was not
+          # printed until 2016
+          # (https://github.com/ruby/openssl/commit/5c20a4c014) when openssl
+          # became a gem. Its first release as a gem was 2.0.0, in ruby 2.4.
+          # (See https://github.com/ruby/ruby/blob/v2_4_0/NEWS)
+          def openssl_cipher_class
+            if ::Gem::Version.new(::OpenSSL::VERSION) < ::Gem::Version.new("2.0.0")
+              ::OpenSSL::Cipher::Cipher
+            else
+              ::OpenSSL::Cipher
+            end
           end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -114,7 +114,11 @@ require_relative 'libs/user'
 require_relative 'libs/user_session'
 require_relative 'libs/company'
 
-Authlogic::CryptoProviders::AES256.key = "myafdsfddddddddddddddddddddddddddddddddddddddddddddddd"
+# Recent change, 2017-10-23: We had used a 54-letter string here. In the default
+# encoding, UTF-8, that's 54 bytes, which is clearly incorrect for an algorithm
+# with a 256-bit key, but I guess it worked. With the release of ruby 2.4 (and
+# thus openssl gem 2.0), it is more strict, and must be exactly 32 bytes.
+Authlogic::CryptoProviders::AES256.key = ::OpenSSL::Random.random_bytes(32)
 
 class ActiveSupport::TestCase
   include ActiveRecord::TestFixtures


### PR DESCRIPTION
Mostly just improving the explanation of AC:Parameters deprecation, but I also had to backport some test suite stuff from master to get my tests passing locally.