### PR TITLE
Load ActiveSupport earlier

### DIFF
--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -1,3 +1,9 @@
+# Authlogic uses ActiveSupport's core extensions like `strip_heredoc`, which
+# ActiveRecord does not `require`. It's possible that we could save a few
+# milliseconds by loading only the specific core extensions we need, but
+# `all.rb` is simpler. We can revisit this decision if it becomes a problem.
+require "active_support/all"
+
 require "active_record"
 
 path = File.dirname(__FILE__) + "/authlogic/"


### PR DESCRIPTION
This allows us to use, eg. `strip_heredoc` anywhere in authlogic (we already use it in some places).

This is a forward-port of 26b626c