### PR TITLE
SameSite cookie support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   * Our mutable constants (e.g. arrays, hashes) are now frozen.
 
 * Added
+  * [#586](https://github.com/binarylogic/authlogic/pull/586) Support for SameSite cookies
   * [#581](https://github.com/binarylogic/authlogic/pull/581) Support for rails 5.2
   * Support for ruby 2.4, specifically openssl gem 2.0
   * [#98](https://github.com/binarylogic/authlogic/issues/98)

--- a/lib/authlogic/test_case/mock_cookie_jar.rb
+++ b/lib/authlogic/test_case/mock_cookie_jar.rb
@@ -1,9 +1,16 @@
 module Authlogic
   module TestCase
     class MockCookieJar < Hash # :nodoc:
+      attr_accessor :set_cookies
+
       def [](key)
         hash = super
         hash && hash[:value]
+      end
+
+      def []=(key, options)
+        (@set_cookies ||= {})[key.to_s] = options
+        super
       end
 
       def delete(key, _options = {})


### PR DESCRIPTION
Add ability to support cookies that set the SameSite flag to "Strict" or "Lax".

See spec:
https://tools.ietf.org/html/draft-west-first-party-cookies-07

See Rack support:
https://github.com/rack/rack/blob/master/test/spec_response.rb#L118

I leave the validation of setting a correct value to Rack.
