### PR TITLE
Dup ActiveRecord gem version before freezing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added
   * None
 * Fixed
-  * None
+  * Remove side effects on ActiveRecord.gem_version
 
 ## 4.0.0 (2018-03-18)
 

--- a/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
+++ b/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
@@ -6,7 +6,10 @@ module Authlogic
       # The query used by public-API method `find_by_smart_case_login_field`.
       # @api private
       class FindWithCase
-        AR_GEM_VERSION = ActiveRecord.gem_version.freeze
+        # Since freezing modifies the object in place, and since
+        # ActiveRecord.gem_version is a constant, we dup it to avoid side
+        # effects outside Authlogic
+        AR_GEM_VERSION = ActiveRecord.gem_version.dup.freeze
 
         # @api private
         def initialize(model_class, field, value, sensitive)


### PR DESCRIPTION
Hi there,

### Context

Updating the Authlogic gem this morning, I found myself stuck because of our CI running [bundler-audit](https://github.com/rubysec/bundler-audit).
It notably relies on RubyGem interface to make verifications, with things like [this](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/requirement.rb#L24) (please notice the `Gem::Version#bump` that modifies the underlying object here).

### Proposed solution

Long story short : `.dup` ActiveRecord gem version before freezing it (I went for the conservative solution but maybe we could let go of the `.dup.freeze` altogether).

Since freezing modifies the object in place, and since ActiveRecord.gem_version is a constant, doing so has repercussions outside the scope of Authlogic, which does not look like a desirable behavior.

For reference, I pinned down the change to this commit : 46859b508ad61003af08c38ea0936a3ab793d86f

I hope this change looks reasonable enough !