### PR TITLE
Make scrypt an optional dependency

### DIFF
--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -23,10 +23,10 @@ require "authlogic/version"
   s.add_dependency 'activerecord', ['>= 4.2', '< 5.3']
   s.add_dependency 'activesupport', ['>= 4.2', '< 5.3']
   s.add_dependency 'request_store', '~> 1.0'
-  s.add_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'bcrypt', '~> 3.1'
   s.add_development_dependency 'byebug', '~> 10.0'
   s.add_development_dependency 'rubocop', '~> 0.51.0'
+  s.add_development_dependency 'scrypt', '>= 1.2', '< 4.0'
   s.add_development_dependency 'timecop', '~> 0.7'
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
Make the `scrypt` gem a development dependency to avoid unnecessary installation when another provider is used, and also to allow the `authlogic` gem to be used under JRuby, where the `scrypt` gem doesn't work due to its C extensions.

This will likely need some kind of documentation update to indicate that the `scrypt` gem needs to be added to the `Gemfile` when using the default provider.