### PR TITLE
Rewrite the Authlogic::Regex module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,3 +99,8 @@ Style/ClassAndModuleChildren:
 # they are different (http://bit.ly/2hSQAGm)
 Style/ModuleFunction:
   Enabled: false
+
+# The decision of when to use slashes `/foo/` or percent-r `%r{foo}` is too
+# subtle to lint. Use whichever requires fewer backslash escapes.
+Style/RegexpLiteral:
+  AllowInnerSlashes: true

--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -99,7 +99,7 @@ module Authlogic
           rw_config(
             :validates_format_of_email_field_options,
             value,
-            with: Authlogic::Regex.email,
+            with: Authlogic::Regex::EMAIL,
             message: Proc.new do
                        I18n.t(
                          'error_messages.email_invalid',

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -88,7 +88,7 @@ module Authlogic
           rw_config(
             :validates_format_of_login_field_options,
             value,
-            with: Authlogic::Regex.login,
+            with: Authlogic::Regex::LOGIN,
             message: proc do
                        I18n.t(
                          'error_messages.login_invalid',

--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -11,14 +11,14 @@ module Authlogic
     # and by reading this website:
     # http://www.regular-expressions.info/email.html, which is an excellent
     # resource for regular expressions.
-    def self.email
-      @email_regex ||= begin
-        email_name_regex  = '[A-Z0-9_\.&%\+\-\']+'
-        domain_head_regex = '(?:[A-Z0-9\-]+\.)+'
-        domain_tld_regex  = '(?:[A-Z]{2,25})'
-        /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/i
-      end
-    end
+    EMAIL = /
+      \A
+      [A-Z0-9_.&%+\-']+   # mailbox
+      @
+      (?:[A-Z0-9\-]+\.)+  # subdomains
+      (?:[A-Z]{2,25})     # TLD
+      \z
+    /ix
 
     # A draft regular expression for internationalized email addresses. Given
     # that the standard may be in flux, this simply emulates @email_regex but
@@ -34,23 +34,46 @@ module Authlogic
     # http://www.unicode.org/faq/idn.html
     # http://ruby-doc.org/core-2.1.5/Regexp.html#class-Regexp-label-Character+Classes
     # http://en.wikipedia.org/wiki/Unicode_character_property#General_Category
-    def self.email_nonascii
-      @email_nonascii_regex ||= begin
-        # TODO: Rewrite this as a single regex without string interpolation,
-        # but spread it over multiple lines using "x mode" /pattern/x.
-        # "x mode" allows for comments.
-        email_name_regex = '[^[:cntrl:][@\[\]\^ \!\"#$\(\)*,/:;<=>\?`{|}~\\\]]+'
-        domain_head_regex = '(?:[^[:cntrl:][@\[\]\^ \!\"#$&\(\)*,/:;<=>\?`{|}~\\\_\.%\+\']]+\.)+'
-        crazy_character_class = '[@\[\]\^ \!\"#$&\(\)*,/:;<=>\?`{|}~\\\_\.%\+\-\'0-9]]'
-        domain_tld_regex = '(?:[^[:cntrl:]' + crazy_character_class + '{2,25})'
-        /\A#{email_name_regex}@#{domain_head_regex}#{domain_tld_regex}\z/
-      end
-    end
+    EMAIL_NONASCII = /
+      \A
+      [^[:cntrl:][@\[\]\^ \!"\#$\(\)*,\/:;<=>?`{|}~\\]]+                        # mailbox
+      @
+      (?:[^[:cntrl:][@\[\]\^ \!\"\#$&\(\)*,\/:;<=>\?`{|}~\\_.%+']]+\.)+         # subdomains
+      (?:[^[:cntrl:][@\[\]\^ \!\"\#$&\(\)*,\/:;<=>\?`{|}~\\_.%+\-'0-9]]{2,25})  # TLD
+      \z
+    /x
 
     # A simple regular expression that only allows for letters, numbers, spaces, and
     # .-_@+. Just a standard login / username regular expression.
+    LOGIN = /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/
+
+    # Accessing the above constants using the following methods is deprecated.
+
+    # @deprecated
+    def self.email
+      ::ActiveSupport::Deprecation.warn(
+        'Authlogic::Regex.email is deprecated, use Authlogic::Regex::EMAIL',
+        caller(1)
+      )
+      EMAIL
+    end
+
+    # @deprecated
+    def self.email_nonascii
+      ::ActiveSupport::Deprecation.warn(
+        'Authlogic::Regex.email_nonascii is deprecated, use Authlogic::Regex::EMAIL_NONASCII',
+        caller(1)
+      )
+      EMAIL_NONASCII
+    end
+
+    # @deprecated
     def self.login
-      /\A[a-zA-Z0-9_][a-zA-Z0-9\.+\-_@ ]+\z/
+      ::ActiveSupport::Deprecation.warn(
+        'Authlogic::Regex.login is deprecated, use Authlogic::Regex::LOGIN',
+        caller(1)
+      )
+      LOGIN
     end
   end
 end

--- a/test/acts_as_authentic_test/email_test.rb
+++ b/test/acts_as_authentic_test/email_test.rb
@@ -94,7 +94,7 @@ module ActsAsAuthenticTest
 
     def test_validates_format_of_email_field_options_config
       default = {
-        with: Authlogic::Regex.email,
+        with: Authlogic::Regex::EMAIL,
         message: proc do
           I18n.t(
             'error_messages.email_invalid',
@@ -122,7 +122,7 @@ module ActsAsAuthenticTest
       assert_equal default, User.validates_format_of_email_field_options
 
       with_email_nonascii = {
-        with: Authlogic::Regex.email_nonascii,
+        with: Authlogic::Regex::EMAIL_NONASCII,
         message: Proc.new do
           I18n.t(
             'error_messages.email_invalid_international',
@@ -213,11 +213,11 @@ module ActsAsAuthenticTest
 
     def test_validates_format_of_nonascii_email_field
       (GOOD_ASCII_EMAILS + GOOD_ISO88591_EMAILS + GOOD_UTF8_EMAILS).each do |e|
-        assert e =~  Authlogic::Regex.email_nonascii, "Good email should validate: #{e}"
+        assert e =~ Authlogic::Regex::EMAIL_NONASCII, "Good email should validate: #{e}"
       end
 
       (BAD_ASCII_EMAILS + BAD_ISO88591_EMAILS + BAD_UTF8_EMAILS).each do |e|
-        assert e !~  Authlogic::Regex.email_nonascii, "Bad email should not validate: #{e}"
+        assert e !~ Authlogic::Regex::EMAIL_NONASCII, "Bad email should not validate: #{e}"
       end
     end
 


### PR DESCRIPTION
1. Use x-mode regexes, which are much more readable than
   the string interpolation we had been using.
2. They're constant, so make them constants