### PR TITLE
Deprecate crypto_providers/wordpress.rb

### DIFF
--- a/lib/authlogic/crypto_providers.rb
+++ b/lib/authlogic/crypto_providers.rb
@@ -7,5 +7,7 @@ module Authlogic
     autoload :BCrypt, "authlogic/crypto_providers/bcrypt"
     autoload :AES256, "authlogic/crypto_providers/aes256"
     autoload :SCrypt, "authlogic/crypto_providers/scrypt"
+    # crypto_providers/wordpress.rb has never been autoloaded, and now it is
+    # deprecated.
   end
 end

--- a/lib/authlogic/crypto_providers/wordpress.rb
+++ b/lib/authlogic/crypto_providers/wordpress.rb
@@ -1,6 +1,35 @@
 require 'digest/md5'
+
+::ActiveSupport::Deprecation.warn(
+  <<-EOS,
+    authlogic/crypto_providers/wordpress.rb is deprecated without replacement.
+    Yes, the entire file. Don't `require` it. Let us know ASAP if you are still
+    using it.
+
+    Reasons for deprecation: This file is not autoloaded by
+    `authlogic/crypto_providers.rb`. It's not documented. There are no tests.
+    So, it's likely used by a *very* small number of people, if any. It's never
+    had any contributions except by its original author, Jeffry Degrande, in
+    2009. It is unclear why it should live in the main authlogic codebase. It
+    could be in a separate gem, authlogic-wordpress, or it could just live in
+    Jeffry's codebase, if he still even needs it, in 2018, nine years later.
+  EOS
+  caller(1)
+)
+
 module Authlogic
   module CryptoProviders
+    # Crypto provider to transition from wordpress user accounts. Written by
+    # Jeffry Degrande in 2009. First released in 2.1.3.
+    #
+    # Problems:
+    #
+    # - There are no tests.
+    # - We can't even figure out how to run this without it crashing.
+    # - Presumably it implements some spec, but it doesn't mention which.
+    # - It is not documented anywhere.
+    # - There is no PR associated with this, and no discussion about it could be found.
+    #
     class Wordpress
       class << self
         ITOA64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.freeze

--- a/test/crypto_provider_test/wordpress_test.rb
+++ b/test/crypto_provider_test/wordpress_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+::ActiveSupport::Deprecation.silence do
+  require 'authlogic/crypto_providers/wordpress'
+end
+
+module CryptoProviderTest
+  class WordpressTest < ActiveSupport::TestCase
+    def test_matches
+      plain = "banana"
+      salt = "aaa"
+      crypted = "xxx0nope"
+      # I couldn't figure out how to even execute this method without it
+      # crashing. Maybe, when Jeffry wrote it in 2009, `Digest::MD5.digest`
+      # worked differently. He was probably using ruby 1.9 back then.
+      # Given that I can't even figure out how to run it, and for all the other
+      # reasons I've given in `wordpress.rb`, I'm just going to deprecate
+      # the whole file. -Jared 2018-04-09
+      assert_raises(NoMethodError) {
+        Authlogic::CryptoProviders::Wordpress.matches?(crypted, plain, salt)
+      }
+    end
+  end
+end


### PR DESCRIPTION
See reasons given in comments and in deprecation warning message.