### PR TITLE
Enable testing without bundler

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,3 +111,9 @@ Style/ModuleFunction:
 # subtle to lint. Use whichever requires fewer backslash escapes.
 Style/RegexpLiteral:
   AllowInnerSlashes: true
+
+# We use words, like `$LOAD_PATH`, because they are much less confusing that
+# arcane symbols like `$:`. Unfortunately, we must then `require "English"` in
+# a few places, but it's worth it so that we can read our code.
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,13 @@ Layout/MultilineMethodCallIndentation:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Metrics/AbcSize:
+  Exclude:
+    # In an ideal world tests would be held to the same ABC metric as production
+    # code. In practice, time spent doing so is not nearly as valuable as
+    # spending the same time improving production code.
+    - test/**/*
+
 # Questionable value compared to metrics like AbcSize or CyclomaticComplexity.
 Metrics/BlockLength:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 58
 Metrics/AbcSize:
-  Max: 43
+  Max: 32
 
 # Offense count: 4
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -126,13 +126,6 @@ Style/RescueModifier:
   Exclude:
     - 'lib/authlogic/acts_as_authentic/session_maintenance.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: SupportedStyles.
-# SupportedStyles: use_perl_names, use_english_names
-Style/SpecialGlobalVars:
-  EnforcedStyle: use_perl_names
-
 # Offense count: 507
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles, ConsistentQuotesInMultiline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,13 @@ BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-4.2.x \
   bundle exec ruby –I test path/to/test.rb
 ```
 
+Bundler can be omitted, and the latest installed version of a gem dependency
+will be used. This is only suitable for certain unit tests.
+
+```
+ruby –I test path/to/test.rb
+```
+
 ### Linting
 
 Running `rake` also runs a linter, rubocop. Contributions must pass both

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -1,4 +1,5 @@
-$:.push File.expand_path('lib', __dir__)
+require "English"
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require "authlogic/version"
 
 ::Gem::Specification.new do |s|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -104,16 +104,18 @@ ActiveRecord::Schema.define(version: 1) do
   end
 end
 
-require_relative '../lib/authlogic'
-require_relative '../lib/authlogic/test_case'
-require_relative 'libs/project'
-require_relative 'libs/affiliate'
-require_relative 'libs/employee'
-require_relative 'libs/employee_session'
-require_relative 'libs/ldaper'
-require_relative 'libs/user'
-require_relative 'libs/user_session'
-require_relative 'libs/company'
+require 'English'
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+require 'authlogic'
+require 'authlogic/test_case'
+require 'libs/project'
+require 'libs/affiliate'
+require 'libs/employee'
+require 'libs/employee_session'
+require 'libs/ldaper'
+require 'libs/user'
+require 'libs/user_session'
+require 'libs/company'
 
 # Recent change, 2017-10-23: We had used a 54-letter string here. In the default
 # encoding, UTF-8, that's 54 bytes, which is clearly incorrect for an algorithm


### PR DESCRIPTION
I'm not a big minitest user, but I think it is common to run tests using eg. `ruby -I test path/to/test`. That was not working for me, and I think it's because authlogic was not on $LOAD_PATH.