### PR TITLE
Deprecate support for restful_authentication

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,12 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Exclude:
+    # crypto_providers/wordpress is deprecated so we will not attempt to
+    # improve its quality.
+    - lib/authlogic/crypto_providers/wordpress.rb
+
 # Aim for 80, but 100 is OK.
 Metrics/LineLength:
   Max: 100

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,10 +10,6 @@
 Metrics/AbcSize:
   Max: 28
 
-# Offense count: 4
-Metrics/CyclomaticComplexity:
-  Max: 8
-
 # Offense count: 3
 Metrics/PerceivedComplexity:
   Max: 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * None
 * Deprecated
   * crypto_providers/wordpress.rb, without replacement
+  * restful_authentication, without replacement
 
 ## 4.0.1 (2018-03-20)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ To run a single test:
 
 ```
 BUNDLE_GEMFILE=test/gemfiles/Gemfile.rails-4.2.x \
-  bundle exec ruby –I test path/to/test.rb
+  bundle exec ruby -I test path/to/test.rb
 ```
 
 Bundler can be omitted, and the latest installed version of a gem dependency

--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -106,7 +106,11 @@ end
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Password
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::PerishableToken
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::PersistenceToken
+
+# RestfulAuthentication is deprecated. See comments in
+# acts_as_authentic/restful_authentication.rb
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::RestfulAuthentication
+
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::SessionMaintenance
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::SingleAccessToken
 ::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::ValidationsScope

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -337,13 +337,7 @@ module Authlogic
             attempted_password,
             check_against_database = check_passwords_against_database?
           )
-            crypted =
-              if check_against_database && send("#{crypted_password_field}_changed?")
-                send("#{crypted_password_field}_was")
-              else
-                send(crypted_password_field)
-              end
-
+            crypted = crypted_password_to_validate_against(check_against_database)
             return false if attempted_password.blank? || crypted.blank?
             before_password_verification
 
@@ -381,6 +375,14 @@ module Authlogic
           alias_method :randomize_password!, :reset_password!
 
           private
+
+            def crypted_password_to_validate_against(check_against_database)
+              if check_against_database && send("#{crypted_password_field}_changed?")
+                send("#{crypted_password_field}_was")
+              else
+                send(crypted_password_field)
+              end
+            end
 
             def check_passwords_against_database?
               self.class.check_passwords_against_database == true

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -326,11 +326,13 @@ module Authlogic
             after_password_set
           end
 
-          # Accepts a raw password to determine if it is the correct password or not.
-          # Notice the second argument. That defaults to the value of
-          # check_passwords_against_database. See that method for more information, but
-          # basically it just tells Authlogic to check the password against the value in
-          # the database or the value in the object.
+          # Accepts a raw password to determine if it is the correct password.
+          #
+          # - attempted_password [String] - password entered by user
+          # - check_against_database [boolean] - Should we check the password
+          #   against the value in the database or the value in the object?
+          #   Default taken from config option check_passwords_against_database.
+          #   See config method for more information.
           def valid_password?(
             attempted_password,
             check_against_database = check_passwords_against_database?

--- a/lib/authlogic/acts_as_authentic/restful_authentication.rb
+++ b/lib/authlogic/acts_as_authentic/restful_authentication.rb
@@ -13,6 +13,15 @@ module Authlogic
       # Configures the restful_authentication aspect of acts_as_authentic.
       # These methods become class methods of ::ActiveRecord::Base.
       module Config
+        DPR_MSG = <<-STR.squish
+          Support for transitioning to authlogic from restful_authentication
+          (%s) is deprecated without replacement. restful_authentication is no
+          longer used in the ruby community, and the transition away from it is
+          complete. There is only one version of restful_authentication on
+          rubygems.org, it was released in 2009, and it's only compatible with
+          rails 2.3. It has been nine years since it was released.
+        STR
+
         # Switching an existing app to Authlogic from restful_authentication? No
         # problem, just set this true and your users won't know anything
         # changed. From your database perspective nothing will change at all.
@@ -28,7 +37,14 @@ module Authlogic
           set_restful_authentication_config if value
           r
         end
-        alias_method :act_like_restful_authentication=, :act_like_restful_authentication
+
+        def act_like_restful_authentication=(value = nil)
+          ::ActiveSupport::Deprecation.warn(
+            format(DPR_MSG, "act_like_restful_authentication="),
+            caller(1)
+          )
+          act_like_restful_authentication(value)
+        end
 
         # This works just like act_like_restful_authentication except that it
         # will start transitioning your users to the algorithm you specify with
@@ -42,10 +58,14 @@ module Authlogic
           set_restful_authentication_config if value
           r
         end
-        alias_method(
-          :transition_from_restful_authentication=,
-          :transition_from_restful_authentication
-        )
+
+        def transition_from_restful_authentication=(value = nil)
+          ::ActiveSupport::Deprecation.warn(
+            format(DPR_MSG, "transition_from_restful_authentication="),
+            caller(1)
+          )
+          transition_from_restful_authentication(value)
+        end
 
         private
 

--- a/test/acts_as_authentic_test/restful_authentication_test.rb
+++ b/test/acts_as_authentic_test/restful_authentication_test.rb
@@ -2,6 +2,15 @@ require "test_helper"
 
 module ActsAsAuthenticTest
   class RestfulAuthenticationTest < ActiveSupport::TestCase
+    def setup
+      @old_deprecation_behavior = ::ActiveSupport::Deprecation.behavior
+      ::ActiveSupport::Deprecation.behavior = :silence
+    end
+
+    def teardown
+      ::ActiveSupport::Deprecation.behavior = @old_deprecation_behavior
+    end
+
     def test_act_like_restful_authentication_config
       refute User.act_like_restful_authentication
       refute Employee.act_like_restful_authentication


### PR DESCRIPTION
Also, various docs and linting.

`CryptoProviders::SHA1` is not deprecated, because it is very likely that people are still using it. They shouldn't use it, but we will probably continue to support SHA1 for a long time.

When we do eventually remove support for restful_authentication, some of the most complicated parts of `acts_as_authentic/password.rb` will be simpler.