### PR TITLE
bug fix for instance variable not defined for @id and @password

### DIFF
--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -34,7 +34,7 @@ module Authlogic
       # Lastly, to retrieve your session with the id check out the find class
       # method.
       def id
-        @id
+        @id ||= nil
       end
 
       private

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -228,7 +228,7 @@ module Authlogic
           self.class.class_eval <<-EOS, __FILE__, __LINE__ + 1
               private
                 def protected_#{password_field}
-                  @#{password_field}
+                  @#{password_field} ||= nil
                 end
             EOS
         end


### PR DESCRIPTION
Bug fix for ruby warning (Instance variable not defined when running rails test suite)
Essentially initialize @id and @password to nil if not defined

