### PR TITLE
bug fix for instance variable not defined for @id and @password

### DIFF
--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -3,6 +3,12 @@ module Authlogic
     # Allows you to separate sessions with an id, ultimately letting you create
     # multiple sessions for the same user.
     module Id
+
+      def initialize
+        @id = nil
+        super
+      end
+
       def self.included(klass)
         klass.class_eval do
           attr_writer :id
@@ -34,7 +40,7 @@ module Authlogic
       # Lastly, to retrieve your session with the id check out the find class
       # method.
       def id
-        @id ||= nil
+        @id
       end
 
       private

--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -3,7 +3,6 @@ module Authlogic
     # Allows you to separate sessions with an id, ultimately letting you create
     # multiple sessions for the same user.
     module Id
-
       def initialize
         @id = nil
         super

--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -34,7 +34,7 @@ module Authlogic
       # Lastly, to retrieve your session with the id check out the find class
       # method.
       def id
-        @id
+        @id ||= nil
       end
 
       private

--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -3,7 +3,7 @@ module Authlogic
     # Allows you to separate sessions with an id, ultimately letting you create
     # multiple sessions for the same user.
     module Id
-      def initialize(*args*)
+      def initialize(*args)
         @id = nil
         super
       end

--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -3,7 +3,7 @@ module Authlogic
     # Allows you to separate sessions with an id, ultimately letting you create
     # multiple sessions for the same user.
     module Id
-      def initialize
+      def initialize(*args*)
         @id = nil
         super
       end

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -2,13 +2,6 @@ module Authlogic
   module Session
     # Handles authenticating via a traditional username and password.
     module Password
-
-      def initialize
-
-        instance_variable_set('@password_changed', nil)
-        super
-      end
-
       def self.included(klass)
         klass.class_eval do
           extend Config
@@ -141,6 +134,7 @@ module Authlogic
             configure_password_methods
             self.class.configured_password_methods = true
           end
+          instance_variable_set("@#{password_field}", nil)
           super
         end
 

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -4,7 +4,7 @@ module Authlogic
     module Password
 
       def initialize
-        @password_changed = nil
+        instance_variable_set('#@{password_field}', nil)
         super
       end
 

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -2,6 +2,12 @@ module Authlogic
   module Session
     # Handles authenticating via a traditional username and password.
     module Password
+
+      def initialize
+        instance_variable_set("@#{password_field}", nil)
+        super
+      end
+
       def self.included(klass)
         klass.class_eval do
           extend Config
@@ -228,7 +234,7 @@ module Authlogic
           self.class.class_eval <<-EOS, __FILE__, __LINE__ + 1
               private
                 def protected_#{password_field}
-                  @#{password_field} ||= nil
+                  @#{password_field}
                 end
             EOS
         end

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -4,7 +4,7 @@ module Authlogic
     module Password
 
       def initialize
-        instance_variable_set("@#{password_field}", nil)
+        @password_changed = nil
         super
       end
 

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -4,7 +4,8 @@ module Authlogic
     module Password
 
       def initialize
-        instance_variable_set('#@{password_field}', nil)
+
+        instance_variable_set('@password_changed', nil)
         super
       end
 

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -228,7 +228,7 @@ module Authlogic
           self.class.class_eval <<-EOS, __FILE__, __LINE__ + 1
               private
                 def protected_#{password_field}
-                  @#{password_field}
+                  @#{password_field} ||= nil
                 end
             EOS
         end


### PR DESCRIPTION
Bug fix for ruby warning (Instance variable not initialized when running rails test suite)
Initialize @id and @password to nil if not defined



