### PR TITLE
Deprecate AES256, guide users to choose a better crypto provider

### DIFF
--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -211,6 +211,7 @@ module Authlogic
         # * <tt>Default:</tt> CryptoProviders::SCrypt
         # * <tt>Accepts:</tt> Class
         def crypto_provider(value = nil)
+          CryptoProviders::Guidance.new(value).impart_wisdom
           rw_config(:crypto_provider, value, CryptoProviders::SCrypt)
         end
         alias_method :crypto_provider=, :crypto_provider

--- a/lib/authlogic/crypto_providers/md5.rb
+++ b/lib/authlogic/crypto_providers/md5.rb
@@ -6,7 +6,8 @@ module Authlogic
     # I highly discourage using this crypto provider as it superbly inferior
     # to your other options.
     #
-    # Please use any other provider offered by Authlogic.
+    # Please use any other provider offered by Authlogic (except AES256, that
+    # would be even worse).
     class MD5
       class << self
         attr_accessor :join_token


### PR DESCRIPTION
AES256, because it is reversible, seems like such a poor choice that I think we should deprecate it. WDYT?

MD5 and SHA-1 are also poor choices. We shouldn't deprecate them yet, because people might still be transitioning (`transition_from_crypto_providers`) but I think we should print a warning.

SHA-256 and SHA-512 are reasonable choices, and popular I bet, but I'd like to print a warning, recommending an adaptive algorithm instead. Too naggy?

In addition to the above questions, I'd welcome any corrections to my copy-writing, specifically where I attempt to describe vulnerabilities. To that end, I'll take the liberty of CC'ing @pbhogan and @stakach from scrypt, @tjschuck and @tenderlove from bcrypt. Thanks in advance for taking a look.