### PR TITLE
Various 2018-09-10

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,12 +22,6 @@ Style/ClassVars:
   Exclude:
     - 'lib/authlogic/i18n.rb'
 
-Style/FrozenStringLiteralComment:
-  Exclude:
-    # Freezing strings in lib would be a breaking change. We'll have to wait
-    # for the next major version.
-    - lib/**/*
-
 # Offense count: 4
 Style/MethodMissingSuper:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 10
 Metrics/AbcSize:
-  Max: 18.5
+  Max: 18.3
 
 # Offense count: 59
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ cherry-pick it from the stable branch into master.
 ## 5.0.0 (Unreleased)
 
 * Breaking Changes
-  * Drop AES256 crypto provider, deprecated in 4.2.0
-  * Drop support for transitioning from restful_authentication, deprecated in 4.1.0
+  * [#617](https://github.com/binarylogic/authlogic/pull/617) -
+    Drop AES-256 crypto provider, deprecated in 4.2.0
+  * [#617](https://github.com/binarylogic/authlogic/pull/617) -
+    Drop restful_authentication, deprecated in 4.1.0
   * Uses `frozen_string_literal`, so assume all strings returned are frozen
 * Added
   * None

--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -47,6 +47,7 @@ path = File.dirname(__FILE__) + "/authlogic/"
   "session/http_auth",
   "session/id",
   "session/klass",
+  "session/magic_column/assigns_last_request_at",
   "session/magic_columns",
   "session/magic_states",
   "session/params",

--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Authlogic uses ActiveSupport's core extensions like `strip_heredoc` and
 # `squish`. ActiveRecord does not `require` these exensions, so we must.
 #

--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # Provides the base functionality for acts_as_authentic

--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # Sometimes models won't have an explicit "login" or "username" field.

--- a/lib/authlogic/acts_as_authentic/logged_in_status.rb
+++ b/lib/authlogic/acts_as_authentic/logged_in_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # Since web applications are stateless there is not sure fire way to tell if

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "authlogic/acts_as_authentic/queries/find_with_case"
 
 module Authlogic

--- a/lib/authlogic/acts_as_authentic/magic_columns.rb
+++ b/lib/authlogic/acts_as_authentic/magic_columns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # Magic columns are like ActiveRecord's created_at and updated_at columns. They are

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # This module has a lot of neat functionality. It is responsible for encrypting your

--- a/lib/authlogic/acts_as_authentic/perishable_token.rb
+++ b/lib/authlogic/acts_as_authentic/perishable_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # This provides a handy token that is "perishable", meaning the token is

--- a/lib/authlogic/acts_as_authentic/persistence_token.rb
+++ b/lib/authlogic/acts_as_authentic/persistence_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # Maintains the persistence token, the token responsible for persisting sessions. This token

--- a/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
+++ b/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
@@ -21,26 +21,10 @@ module Authlogic
 
         # @api private
         def execute
-          bind(comparison).first
+          @model_class.where(comparison).first
         end
 
         private
-
-        # - comparison - Arel::Nodes::Equality
-        #
-        # @api private
-        def bind(comparison)
-          if AR_GEM_VERSION >= Gem::Version.new("5")
-            bind = ActiveRecord::Relation::QueryAttribute.new(
-              @field,
-              @value,
-              ActiveRecord::Type::Value.new
-            )
-            @model_class.where(comparison, bind)
-          else
-            @model_class.where(comparison)
-          end
-        end
 
         # @api private
         # @return Arel::Nodes::Equality

--- a/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
+++ b/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
@@ -26,7 +26,7 @@ module Authlogic
 
         private
 
-        # - comparison - Arel::Predications::Nodes::Equality
+        # - comparison - Arel::Nodes::Equality
         #
         # @api private
         def bind(comparison)
@@ -43,15 +43,24 @@ module Authlogic
         end
 
         # @api private
+        # @return Arel::Nodes::Equality
         def comparison
-          if !@sensitive
-            @model_class.connection.case_insensitive_comparison(
-              @model_class.arel_table,
-              @field,
-              @model_class.columns_hash[@field],
-              @value
-            )
-          elsif AR_GEM_VERSION >= Gem::Version.new("5.0")
+          @sensitive ? sensitive_comparison : insensitive_comparison
+        end
+
+        # @api private
+        def insensitive_comparison
+          @model_class.connection.case_insensitive_comparison(
+            @model_class.arel_table,
+            @field,
+            @model_class.columns_hash[@field],
+            @value
+          )
+        end
+
+        # @api private
+        def sensitive_comparison
+          if AR_GEM_VERSION >= Gem::Version.new("5.0")
             @model_class.connection.case_sensitive_comparison(
               @model_class.arel_table,
               @field,

--- a/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
+++ b/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
@@ -21,27 +21,29 @@ module Authlogic
 
         # @api private
         def execute
-          bind(relation).first
+          bind(comparison).first
         end
 
         private
 
+        # - comparison - Arel::Predications::Nodes::Equality
+        #
         # @api private
-        def bind(relation)
+        def bind(comparison)
           if AR_GEM_VERSION >= Gem::Version.new("5")
             bind = ActiveRecord::Relation::QueryAttribute.new(
               @field,
               @value,
               ActiveRecord::Type::Value.new
             )
-            @model_class.where(relation, bind)
+            @model_class.where(comparison, bind)
           else
-            @model_class.where(relation)
+            @model_class.where(comparison)
           end
         end
 
         # @api private
-        def relation
+        def comparison
           if !@sensitive
             @model_class.connection.case_insensitive_comparison(
               @model_class.arel_table,

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # This is one of my favorite features that I think is pretty cool. It's

--- a/lib/authlogic/acts_as_authentic/single_access_token.rb
+++ b/lib/authlogic/acts_as_authentic/single_access_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # This module is responsible for maintaining the single_access token. For more

--- a/lib/authlogic/acts_as_authentic/validations_scope.rb
+++ b/lib/authlogic/acts_as_authentic/validations_scope.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ActsAsAuthentic
     # Allows you to scope everything to specific fields. See the Config

--- a/lib/authlogic/authenticates_many/association.rb
+++ b/lib/authlogic/authenticates_many/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module AuthenticatesMany
     # An object of this class is used as a proxy for the authenticates_many

--- a/lib/authlogic/authenticates_many/base.rb
+++ b/lib/authlogic/authenticates_many/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   # This allows you to scope your authentication. For example, let's say all users belong
   # to an account, you want to make sure only users that belong to that account can

--- a/lib/authlogic/config.rb
+++ b/lib/authlogic/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   # Mixed into `Authlogic::ActsAsAuthentic::Base` and
   # `Authlogic::Session::Foundation`.

--- a/lib/authlogic/controller_adapters/abstract_adapter.rb
+++ b/lib/authlogic/controller_adapters/abstract_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ControllerAdapters # :nodoc:
     # Allows you to use Authlogic in any framework you want, not just rails. See
@@ -5,7 +7,7 @@ module Authlogic
     # your framework.
     class AbstractAdapter
       E_COOKIE_DOMAIN_ADAPTER = "The cookie_domain method has not been " \
-        "implemented by the controller adapter".freeze
+        "implemented by the controller adapter"
 
       attr_accessor :controller
 

--- a/lib/authlogic/controller_adapters/rack_adapter.rb
+++ b/lib/authlogic/controller_adapters/rack_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module ControllerAdapters
     # Adapter for authlogic to make it function as a Rack middleware.

--- a/lib/authlogic/controller_adapters/rails_adapter.rb
+++ b/lib/authlogic/controller_adapters/rails_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "action_controller"
 
 module Authlogic

--- a/lib/authlogic/controller_adapters/sinatra_adapter.rb
+++ b/lib/authlogic/controller_adapters/sinatra_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Authlogic bridge for Sinatra
 module Authlogic
   module ControllerAdapters

--- a/lib/authlogic/crypto_providers.rb
+++ b/lib/authlogic/crypto_providers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   # The acts_as_authentic method has a crypto_provider option. This allows you
   # to use any type of encryption you like. Just create a class with a class
@@ -32,8 +34,8 @@ module Authlogic
 
     # Guide users to choose a better crypto provider.
     class Guidance
-      BUILTIN_PROVIDER_PREFIX = "Authlogic::CryptoProviders::".freeze
-      NONADAPTIVE_ALGORITHM = <<~EOS.freeze
+      BUILTIN_PROVIDER_PREFIX = "Authlogic::CryptoProviders::"
+      NONADAPTIVE_ALGORITHM = <<~EOS
         You have selected %s as your authlogic crypto provider. This algorithm
         does not have any practical known attacks against it. However, there are
         better choices.
@@ -48,7 +50,7 @@ module Authlogic
         Use the transition_from_crypto_providers option to make the transition
         painless for your users.
       EOS
-      VULNERABLE_ALGORITHM = <<~EOS.freeze
+      VULNERABLE_ALGORITHM = <<~EOS
         You have selected %s as your authlogic crypto provider. It is a poor
         choice because there are known attacks against this algorithm.
 

--- a/lib/authlogic/crypto_providers/bcrypt.rb
+++ b/lib/authlogic/crypto_providers/bcrypt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bcrypt"
 
 module Authlogic

--- a/lib/authlogic/crypto_providers/md5.rb
+++ b/lib/authlogic/crypto_providers/md5.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest/md5"
 
 module Authlogic

--- a/lib/authlogic/crypto_providers/scrypt.rb
+++ b/lib/authlogic/crypto_providers/scrypt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "scrypt"
 
 module Authlogic

--- a/lib/authlogic/crypto_providers/sha1.rb
+++ b/lib/authlogic/crypto_providers/sha1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest/sha1"
 
 module Authlogic

--- a/lib/authlogic/crypto_providers/sha256.rb
+++ b/lib/authlogic/crypto_providers/sha256.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest/sha2"
 
 module Authlogic

--- a/lib/authlogic/crypto_providers/sha512.rb
+++ b/lib/authlogic/crypto_providers/sha512.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest/sha2"
 
 module Authlogic

--- a/lib/authlogic/crypto_providers/wordpress.rb
+++ b/lib/authlogic/crypto_providers/wordpress.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest/md5"
 
 ::ActiveSupport::Deprecation.warn(
@@ -32,7 +34,7 @@ module Authlogic
     #
     class Wordpress
       class << self
-        ITOA64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".freeze
+        ITOA64 = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
         def matches?(crypted, *tokens)
           stretches = 1 << ITOA64.index(crypted[3, 1])

--- a/lib/authlogic/i18n.rb
+++ b/lib/authlogic/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "authlogic/i18n/translator"
 
 module Authlogic

--- a/lib/authlogic/i18n/translator.rb
+++ b/lib/authlogic/i18n/translator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module I18n
     # The default translator used by authlogic/i18n.rb

--- a/lib/authlogic/random.rb
+++ b/lib/authlogic/random.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "securerandom"
 
 module Authlogic

--- a/lib/authlogic/regex.rb
+++ b/lib/authlogic/regex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   # This is a module the contains regular expressions used throughout Authlogic.
   # The point of extracting them out into their own module is to make them

--- a/lib/authlogic/session/activation.rb
+++ b/lib/authlogic/session/activation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "request_store"
 
 module Authlogic

--- a/lib/authlogic/session/active_record_trickery.rb
+++ b/lib/authlogic/session/active_record_trickery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Authlogic looks like ActiveRecord, sounds like ActiveRecord, but its not

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session # :nodoc:
     # This is the most important class in Authlogic. You will inherit this class

--- a/lib/authlogic/session/brute_force_protection.rb
+++ b/lib/authlogic/session/brute_force_protection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # A brute force attacks is executed by hammering a login with as many password

--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Between these callbacks and the configuration, this is the contract between me and

--- a/lib/authlogic/session/cookies.rb
+++ b/lib/authlogic/session/cookies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Handles all authentication that deals with cookies, such as persisting,

--- a/lib/authlogic/session/existence.rb
+++ b/lib/authlogic/session/existence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Provides methods to create and destroy objects. Basically controls their

--- a/lib/authlogic/session/foundation.rb
+++ b/lib/authlogic/session/foundation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Sort of like an interface, it sets the foundation for the class, such as the
@@ -13,7 +15,7 @@ module Authlogic
 
       # :nodoc:
       module InstanceMethods
-        E_AC_PARAMETERS = <<~EOS.freeze
+        E_AC_PARAMETERS = <<~EOS
           Passing an ActionController::Parameters to Authlogic is not allowed.
 
           In Authlogic 3, especially during the transition of rails to Strong

--- a/lib/authlogic/session/http_auth.rb
+++ b/lib/authlogic/session/http_auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Handles all authentication that deals with basic HTTP auth. Which is

--- a/lib/authlogic/session/id.rb
+++ b/lib/authlogic/session/id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Allows you to separate sessions with an id, ultimately letting you create

--- a/lib/authlogic/session/klass.rb
+++ b/lib/authlogic/session/klass.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Handles authenticating via a traditional username and password.

--- a/lib/authlogic/session/magic_column/assigns_last_request_at.rb
+++ b/lib/authlogic/session/magic_column/assigns_last_request_at.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Authlogic
+  module Session
+    module MagicColumn
+      # Assigns the current time to the `last_request_at` attribute.
+      #
+      # 1. The `last_request_at` column must exist
+      # 2. Assignment can be disabled on a per-controller basis
+      # 3. Assignment will not happen more often than `last_request_at_threshold`
+      #   seconds.
+      #
+      # - current_time - a `Time`
+      # - record - eg. a `User`
+      # - controller - an `Authlogic::ControllerAdapters::AbstractAdapter`
+      # - last_request_at_threshold - integer - seconds
+      #
+      # @api private
+      class AssignsLastRequestAt
+        def initialize(current_time, record, controller, last_request_at_threshold)
+          @current_time = current_time
+          @record = record
+          @controller = controller
+          @last_request_at_threshold = last_request_at_threshold
+        end
+
+        def assign
+          return unless assign?
+          @record.last_request_at = @current_time
+        end
+
+        private
+
+        # @api private
+        def assign?
+          @record &&
+            @record.class.column_names.include?("last_request_at") &&
+            @controller.last_request_update_allowed? && (
+              @record.last_request_at.blank? ||
+              @last_request_at_threshold.to_i.seconds.ago >= @record.last_request_at
+            )
+        end
+      end
+    end
+  end
+end

--- a/lib/authlogic/session/magic_columns.rb
+++ b/lib/authlogic/session/magic_columns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Just like ActiveRecord has "magic" columns, such as: created_at and updated_at.

--- a/lib/authlogic/session/magic_states.rb
+++ b/lib/authlogic/session/magic_states.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Authlogic tries to check the state of the record before creating the session. If

--- a/lib/authlogic/session/params.rb
+++ b/lib/authlogic/session/params.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # This module is responsible for authenticating the user via params, which ultimately

--- a/lib/authlogic/session/password.rb
+++ b/lib/authlogic/session/password.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Handles authenticating via a traditional username and password.

--- a/lib/authlogic/session/perishable_token.rb
+++ b/lib/authlogic/session/perishable_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Maintains the perishable token, which is helpful for confirming records or

--- a/lib/authlogic/session/persistence.rb
+++ b/lib/authlogic/session/persistence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Responsible for allowing you to persist your sessions.

--- a/lib/authlogic/session/priority_record.rb
+++ b/lib/authlogic/session/priority_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # The point of this module is to avoid the StaleObjectError raised when

--- a/lib/authlogic/session/scopes.rb
+++ b/lib/authlogic/session/scopes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "request_store"
 
 module Authlogic

--- a/lib/authlogic/session/session.rb
+++ b/lib/authlogic/session/session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Handles all parts of authentication that deal with sessions. Such as persisting a

--- a/lib/authlogic/session/timeout.rb
+++ b/lib/authlogic/session/timeout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Think about financial websites, if you are inactive for a certain period

--- a/lib/authlogic/session/unauthorized_record.rb
+++ b/lib/authlogic/session/unauthorized_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Allows you to create session with an object. Ex:

--- a/lib/authlogic/session/validation.rb
+++ b/lib/authlogic/session/validation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module Session
     # Responsible for session validation

--- a/lib/authlogic/test_case.rb
+++ b/lib/authlogic/test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.dirname(__FILE__) + "/test_case/rails_request_adapter"
 require File.dirname(__FILE__) + "/test_case/mock_cookie_jar"
 require File.dirname(__FILE__) + "/test_case/mock_controller"

--- a/lib/authlogic/test_case/mock_controller.rb
+++ b/lib/authlogic/test_case/mock_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module TestCase
     # Basically acts like a controller but doesn't do anything. Authlogic can interact

--- a/lib/authlogic/test_case/mock_cookie_jar.rb
+++ b/lib/authlogic/test_case/mock_cookie_jar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module TestCase
     # A mock of `ActionDispatch::Cookies::CookieJar`.

--- a/lib/authlogic/test_case/mock_logger.rb
+++ b/lib/authlogic/test_case/mock_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module TestCase
     # Simple class to replace real loggers, so that we can raise any errors being logged.

--- a/lib/authlogic/test_case/mock_request.rb
+++ b/lib/authlogic/test_case/mock_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module TestCase
     class MockRequest # :nodoc:

--- a/lib/authlogic/test_case/rails_request_adapter.rb
+++ b/lib/authlogic/test_case/rails_request_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Authlogic
   module TestCase
     # Adapts authlogic to work with the @request object when testing. This way Authlogic

--- a/test/session_test/magic_columns_test.rb
+++ b/test/session_test/magic_columns_test.rb
@@ -23,7 +23,7 @@ module SessionTest
         old_last_request_at = ben.last_request_at
         assert UserSession.find
         ben.reload
-        assert ben.last_request_at != old_last_request_at
+        assert ben.last_request_at > old_last_request_at
       end
 
       def test_valid_increase_failed_login_count


### PR DESCRIPTION
- Frozen string literals ❄️ 
- Remove some complexity caused by an AR 5.0-specific workaround
- Extract class: `session/magic_column/assigns_last_request_at`