### PR TITLE
Session validation errors: Require ActiveModel

### DIFF
--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -23,6 +23,7 @@ require "authlogic/version"
   s.license = "MIT"
 
   s.required_ruby_version = ">= 2.3.0"
+  s.add_dependency "activemodel", [">= 4.2", "< 5.3"]
   s.add_dependency "activerecord", [">= 4.2", "< 5.3"]
   s.add_dependency "activesupport", [">= 4.2", "< 5.3"]
   s.add_dependency "request_store", "~> 1.0"

--- a/lib/authlogic/session/validation.rb
+++ b/lib/authlogic/session/validation.rb
@@ -16,13 +16,7 @@ module Authlogic
       #         errors.add(:base, "You must be awesome to log in") unless attempted_record.awesome?
       #       end
       #   end
-      class Errors < (defined?(::ActiveModel) ? ::ActiveModel::Errors : ::ActiveRecord::Errors)
-        unless defined?(::ActiveModel)
-          def [](key)
-            value = super
-            value.is_a?(Array) ? value : [value].compact
-          end
-        end
+      class Errors < ::ActiveModel::Errors
       end
 
       # You should use this as a place holder for any records that you find

--- a/lib/authlogic/session/validation.rb
+++ b/lib/authlogic/session/validation.rb
@@ -3,22 +3,27 @@
 module Authlogic
   module Session
     # Responsible for session validation
+    #
+    # The errors in Authlogic work just like ActiveRecord. In fact, it uses
+    # the `ActiveModel::Errors` class. Use it the same way:
+    #
+    # ```
+    # class UserSession
+    #   validate :check_if_awesome
+    #
+    #   private
+    #
+    #   def check_if_awesome
+    #     if login && !login.include?("awesome")
+    #       errors.add(:login, "must contain awesome")
+    #     end
+    #     unless attempted_record.awesome?
+    #       errors.add(:base, "You must be awesome to log in")
+    #     end
+    #   end
+    # end
+    # ```
     module Validation
-      # The errors in Authlogic work JUST LIKE ActiveRecord. In fact, it uses
-      # the exact same ActiveRecord errors class. Use it the same way:
-      #
-      #   class UserSession
-      #     validate :check_if_awesome
-      #
-      #     private
-      #       def check_if_awesome
-      #         errors.add(:login, "must contain awesome") if login && !login.include?("awesome")
-      #         errors.add(:base, "You must be awesome to log in") unless attempted_record.awesome?
-      #       end
-      #   end
-      class Errors < ::ActiveModel::Errors
-      end
-
       # You should use this as a place holder for any records that you find
       # during validation. The main reason for this is to allow other modules to
       # use it if needed. Take the failed_login_count feature, it needs this in
@@ -32,22 +37,9 @@ module Authlogic
         @attempted_record = value
       end
 
-      # The errors in Authlogic work JUST LIKE ActiveRecord. In fact, it uses
-      # the exact same ActiveRecord errors class. Use it the same way:
-      #
-      # === Example
-      #
-      #  class UserSession
-      #    before_validation :check_if_awesome
-      #
-      #    private
-      #      def check_if_awesome
-      #        errors.add(:login, "must contain awesome") if login && !login.include?("awesome")
-      #        errors.add(:base, "You must be awesome to log in") unless attempted_record.awesome?
-      #      end
-      #  end
+      # @api public
       def errors
-        @errors ||= Errors.new(self)
+        @errors ||= ::ActiveModel::Errors.new(self)
       end
 
       # Determines if the information you provided for authentication is valid

--- a/test/session_test/validation_test.rb
+++ b/test/session_test/validation_test.rb
@@ -6,7 +6,7 @@ module SessionTest
   class ValidationTest < ActiveSupport::TestCase
     def test_errors
       session = UserSession.new
-      assert session.errors.is_a?(Authlogic::Session::Validation::Errors)
+      assert_kind_of ::ActiveModel::Errors, session.errors
     end
 
     def test_valid


### PR DESCRIPTION
A story in two acts

1. Drop rails 2 support in our session validation errors class
2. Now our subclass is exactly the same as its parent, ActiveModel::Errors, so just use the parent