### PR TITLE
Deprecate unnecessary validation features

### DIFF
--- a/lib/authlogic/acts_as_authentic/email.rb
+++ b/lib/authlogic/acts_as_authentic/email.rb
@@ -31,6 +31,7 @@ module Authlogic
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
         def validate_email_field(value = nil)
+          deprecate_authlogic_config("validate_email_field")
           rw_config(:validate_email_field, value, true)
         end
         alias_method :validate_email_field=, :validate_email_field
@@ -46,6 +47,7 @@ module Authlogic
         # * <tt>Default:</tt> {:maximum => 100}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_length_of
         def validates_length_of_email_field_options(value = nil)
+          deprecate_authlogic_config("validates_length_of_email_field_options")
           rw_config(:validates_length_of_email_field_options, value, maximum: 100)
         end
         alias_method(
@@ -63,6 +65,7 @@ module Authlogic
         #
         #   merge_validates_length_of_email_field_options :my_option => my_value
         def merge_validates_length_of_email_field_options(options = {})
+          deprecate_authlogic_config("merge_validates_length_of_email_field_options")
           self.validates_length_of_email_field_options =
             validates_length_of_email_field_options.merge(options)
         end
@@ -98,6 +101,7 @@ module Authlogic
         #
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_email_field_options(value = nil)
+          deprecate_authlogic_config("validates_format_of_email_field_options")
           rw_config(
             :validates_format_of_email_field_options,
             value,
@@ -118,6 +122,7 @@ module Authlogic
         # See merge_validates_length_of_email_field_options. The same thing
         # except for validates_format_of_email_field_options.
         def merge_validates_format_of_email_field_options(options = {})
+          deprecate_authlogic_config("merge_validates_format_of_email_field_options")
           self.validates_format_of_email_field_options =
             validates_format_of_email_field_options.merge(options)
         end
@@ -141,6 +146,7 @@ module Authlogic
         #
         # * <tt>Accepts:</tt> Hash of options accepted by validates_uniqueness_of
         def validates_uniqueness_of_email_field_options(value = nil)
+          deprecate_authlogic_config("validates_uniqueness_of_email_field_options")
           rw_config(
             :validates_uniqueness_of_email_field_options,
             value,
@@ -157,6 +163,7 @@ module Authlogic
         # See merge_validates_length_of_email_field_options. The same thing
         # except for validates_uniqueness_of_email_field_options.
         def merge_validates_uniqueness_of_email_field_options(options = {})
+          deprecate_authlogic_config("merge_validates_uniqueness_of_email_field_options")
           self.validates_uniqueness_of_email_field_options =
             validates_uniqueness_of_email_field_options.merge(options)
         end

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -29,6 +29,7 @@ module Authlogic
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
         def validate_login_field(value = nil)
+          deprecate_authlogic_config("validate_login_field")
           rw_config(:validate_login_field, value, true)
         end
         alias_method :validate_login_field=, :validate_login_field
@@ -44,6 +45,7 @@ module Authlogic
         # * <tt>Default:</tt> {:within => 3..100}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_length_of
         def validates_length_of_login_field_options(value = nil)
+          deprecate_authlogic_config("validates_length_of_login_field_options")
           rw_config(:validates_length_of_login_field_options, value, within: 3..100)
         end
         alias_method(
@@ -61,6 +63,7 @@ module Authlogic
         #
         #   merge_validates_length_of_login_field_options :my_option => my_value
         def merge_validates_length_of_login_field_options(options = {})
+          deprecate_authlogic_config("merge_validates_length_of_login_field_options")
           self.validates_length_of_login_field_options =
             validates_length_of_login_field_options.merge(options)
         end
@@ -87,6 +90,7 @@ module Authlogic
         #
         # * <tt>Accepts:</tt> Hash of options accepted by validates_format_of
         def validates_format_of_login_field_options(value = nil)
+          deprecate_authlogic_config("validates_format_of_login_field_options")
           rw_config(
             :validates_format_of_login_field_options,
             value,
@@ -107,6 +111,7 @@ module Authlogic
         # See merge_validates_length_of_login_field_options. The same thing,
         # except for validates_format_of_login_field_options
         def merge_validates_format_of_login_field_options(options = {})
+          deprecate_authlogic_config("merge_validates_format_of_login_field_options")
           self.validates_format_of_login_field_options =
             validates_format_of_login_field_options.merge(options)
         end
@@ -129,6 +134,7 @@ module Authlogic
         #
         # * <tt>Accepts:</tt> Hash of options accepted by validates_uniqueness_of
         def validates_uniqueness_of_login_field_options(value = nil)
+          deprecate_authlogic_config("validates_uniqueness_of_login_field_options")
           rw_config(
             :validates_uniqueness_of_login_field_options,
             value,
@@ -145,6 +151,7 @@ module Authlogic
         # See merge_validates_length_of_login_field_options. The same thing,
         # except for validates_uniqueness_of_login_field_options
         def merge_validates_uniqueness_of_login_field_options(options = {})
+          deprecate_authlogic_config("merge_validates_uniqueness_of_login_field_options")
           self.validates_uniqueness_of_login_field_options =
             validates_uniqueness_of_login_field_options.merge(options)
         end

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -100,6 +100,7 @@ module Authlogic
         # * <tt>Default:</tt> true
         # * <tt>Accepts:</tt> Boolean
         def validate_password_field(value = nil)
+          deprecate_authlogic_config("validate_password_field")
           rw_config(:validate_password_field, value, true)
         end
         alias_method :validate_password_field=, :validate_password_field
@@ -115,6 +116,7 @@ module Authlogic
         # * <tt>Default:</tt> {:minimum => 8, :if => :require_password?}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_length_of
         def validates_length_of_password_field_options(value = nil)
+          deprecate_authlogic_config("validates_length_of_password_field_options")
           rw_config(
             :validates_length_of_password_field_options,
             value,
@@ -137,6 +139,9 @@ module Authlogic
         #
         #   merge_validates_length_of_password_field_options :my_option => my_value
         def merge_validates_length_of_password_field_options(options = {})
+          deprecate_authlogic_config(
+            "merge_validates_length_of_password_field_options"
+          )
           self.validates_length_of_password_field_options =
             validates_length_of_password_field_options.merge(options)
         end
@@ -152,6 +157,9 @@ module Authlogic
         # * <tt>Default:</tt> {:if => :require_password?}
         # * <tt>Accepts:</tt> Hash of options accepted by validates_confirmation_of
         def validates_confirmation_of_password_field_options(value = nil)
+          deprecate_authlogic_config(
+            "validates_confirmation_of_password_field_options"
+          )
           rw_config(
             :validates_confirmation_of_password_field_options,
             value,
@@ -164,6 +172,9 @@ module Authlogic
         # See merge_validates_length_of_password_field_options. The same thing, except for
         # validates_confirmation_of_password_field_options
         def merge_validates_confirmation_of_password_field_options(options = {})
+          deprecate_authlogic_config(
+            "merge_validates_confirmation_of_password_field_options"
+          )
           self.validates_confirmation_of_password_field_options =
             validates_confirmation_of_password_field_options.merge(options)
         end
@@ -179,6 +190,9 @@ module Authlogic
         # * <tt>Default:</tt> validates_length_of_password_field_options
         # * <tt>Accepts:</tt> Hash of options accepted by validates_length_of
         def validates_length_of_password_confirmation_field_options(value = nil)
+          deprecate_authlogic_config(
+            "validates_length_of_password_confirmation_field_options"
+          )
           rw_config(
             :validates_length_of_password_confirmation_field_options,
             value,
@@ -193,6 +207,9 @@ module Authlogic
         # See merge_validates_length_of_password_field_options. The same thing, except for
         # validates_length_of_password_confirmation_field_options
         def merge_validates_length_of_password_confirmation_field_options(options = {})
+          deprecate_authlogic_config(
+            "merge_validates_length_of_password_confirmation_field_options"
+          )
           self.validates_length_of_password_confirmation_field_options =
             validates_length_of_password_confirmation_field_options.merge(options)
         end

--- a/lib/authlogic/acts_as_authentic/validations_scope.rb
+++ b/lib/authlogic/acts_as_authentic/validations_scope.rb
@@ -25,6 +25,7 @@ module Authlogic
         # * <tt>Default:</tt> nil
         # * <tt>Accepts:</tt> Symbol or Array of symbols
         def validations_scope(value = nil)
+          deprecate_authlogic_config("validations_scope")
           rw_config(:validations_scope, value)
         end
         alias_method :validations_scope=, :validations_scope

--- a/lib/authlogic/config.rb
+++ b/lib/authlogic/config.rb
@@ -4,6 +4,16 @@ module Authlogic
   # Mixed into `Authlogic::ActsAsAuthentic::Base` and
   # `Authlogic::Session::Foundation`.
   module Config
+    E_USE_NORMAL_RAILS_VALIDATION = <<~EOS
+      This Authlogic configuration option (%s) is deprecated. Use normal
+      ActiveRecord validations instead. For example, instead of the Authlogic
+      method validates_length_of_email_field_options, you can use
+
+          validates :email, length: { ... }
+
+      These deprecated Authlogic methods will be removed in the next major version.
+    EOS
+
     def self.extended(klass)
       klass.class_eval do
         # TODO: Is this a confusing name, given this module is mixed into
@@ -16,6 +26,12 @@ module Authlogic
     end
 
     private
+
+    def deprecate_authlogic_config(method_name)
+      ::ActiveSupport::Deprecation.warn(
+        format(E_USE_NORMAL_RAILS_VALIDATION, method_name)
+      )
+    end
 
     # This is a one-liner method to write a config setting, read the config
     # setting, and also set a default value for the setting.


### PR DESCRIPTION
I don't understand why Authlogic has these features, when these validations
can be accomplished using normal ActiveRecord validations. 

**Maybe I'm missing something?**

In my own production apps I disable these and I use the normal AR validations.