### PR TITLE
Explicitly use run_callbacks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 10
 Metrics/AbcSize:
-  Max: 18.3
+  Max: 17.4
 
 # Offense count: 59
 # Cop supports --auto-correct.

--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -133,16 +133,6 @@ module Authlogic
         end
       end
 
-      METHODS.each do |method|
-        class_eval(
-          <<-EOS, __FILE__, __LINE__ + 1
-            def #{method}
-              run_callbacks(:#{method})
-            end
-          EOS
-        )
-      end
-
       def save_record(alternate_record = nil)
         r = alternate_record || record
         if r&.changed? && !r.readonly?

--- a/lib/authlogic/session/existence.rb
+++ b/lib/authlogic/session/existence.rb
@@ -54,11 +54,11 @@ module Authlogic
         # terminate a session, thus requiring the user to authenticate again if
         # it is needed.
         def destroy
-          before_destroy
+          run_callbacks :before_destroy
           save_record
           errors.clear
           @record = nil
-          after_destroy
+          run_callbacks :after_destroy
           true
         end
 
@@ -78,10 +78,10 @@ module Authlogic
           if valid?
             self.record = attempted_record
 
-            before_save
-            new_session? ? before_create : before_update
-            new_session? ? after_create : after_update
-            after_save
+            run_callbacks :before_save
+            run_callbacks(new_session? ? :before_create : :before_update)
+            run_callbacks(new_session? ? :after_create : :after_update)
+            run_callbacks :after_save
 
             save_record
             self.new_session = false

--- a/lib/authlogic/session/persistence.rb
+++ b/lib/authlogic/session/persistence.rb
@@ -62,12 +62,12 @@ module Authlogic
           return true unless record.nil?
           self.attempted_record = nil
           self.remember_me = cookie_credentials_remember_me?
-          before_persisting
-          persist
+          run_callbacks :before_persisting
+          run_callbacks :persist
           ensure_authentication_attempted
           if errors.empty? && !attempted_record.nil?
             self.record = attempted_record
-            after_persisting
+            run_callbacks :after_persisting
             save_record
             self.new_session = false
             true

--- a/lib/authlogic/session/validation.rb
+++ b/lib/authlogic/session/validation.rb
@@ -49,18 +49,18 @@ module Authlogic
         errors.clear
         self.attempted_record = nil
 
-        before_validation
-        new_session? ? before_validation_on_create : before_validation_on_update
+        run_callbacks(:before_validation)
+        run_callbacks(new_session? ? :before_validation_on_create : :before_validation_on_update)
 
         # eg. `Authlogic::Session::Password.validate_by_password`
         # This is when `attempted_record` is set.
-        validate
+        run_callbacks(:validate)
 
         ensure_authentication_attempted
 
         if errors.empty?
-          new_session? ? after_validation_on_create : after_validation_on_update
-          after_validation
+          run_callbacks(new_session? ? :after_validation_on_create : :after_validation_on_update)
+          run_callbacks(:after_validation)
         end
 
         save_record(attempted_record)

--- a/test/session_test/callbacks_test.rb
+++ b/test/session_test/callbacks_test.rb
@@ -11,7 +11,7 @@ module SessionTest
     def test_no_callbacks
       assert_equal [], WackyUserSession._persist_callbacks.map(&:filter)
       session = WackyUserSession.new
-      session.send(:persist)
+      session.send(:run_callbacks, :persist)
       assert_equal 0, session.counter
     end
 
@@ -23,7 +23,7 @@ module SessionTest
       )
 
       session = WackyUserSession.new
-      session.send(:persist)
+      session.send(:run_callbacks, :persist)
       assert_equal 1, session.counter
     end
 
@@ -35,7 +35,7 @@ module SessionTest
       )
 
       session = WackyUserSession.new
-      session.send(:persist)
+      session.send(:run_callbacks, :persist)
       assert_equal 2, session.counter
     end
   end


### PR DESCRIPTION
Delete the methods named eg. `before_save`, `validate`, etc. which
were used to run callbacks. Instead, explicitly use `run_callbacks`.

It is very confusing to me to have two different methods named eg.
`before_save`.

1. The class method `before_save` is the "callback installation
method" (my term). This method uses `set_callback` to install a callback
for the eg. `:before_save` *event*.
2. The instance method `before_save` (which this commit deletes)
which just called `run_callbacks(:before_save)`

By deleting the later, we can now easily:

- distinguish "callback installation" from "callback running"
- search the codebase for all `run_callback` sites

This is not a breaking change. The deleted methods were private API.
As such, I don't think we should mention this in the changelog.
Even someone writing a plugin for authlogic would not use the deleted
methods, I don't think.
