### PR TITLE
Rename gemfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ pkg/*
 coverage/*
 benchmarks/*
 .rvmrc
-gemfiles/Gemfile*.lock
+gemfiles/*.lock
 .bundle
 Gemfile.lock
 .ruby-gemset

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,17 @@ rvm:
 # We only test living versions of rails, per the [rails maintenance
 # policy](http://guides.rubyonrails.org/maintenance_policy.html)
 gemfile:
-  - gemfiles/Gemfile.rails-5.2.x
-  - gemfiles/Gemfile.rails-6.0.x
+  - gemfiles/rails-5.2.rb
+  - gemfiles/rails-6.0.rb
 
 matrix:
   exclude:
     # rails 6 will not support ruby < 2.4.1
     - rvm: 2.3.8
-      gemfile: gemfiles/Gemfile.rails-6.0.x
+      gemfile: gemfiles/rails-6.0.rb
     # optimization: don't test intermediate rubies (see above)
     - rvm: 2.4.4
-      gemfile: gemfiles/Gemfile.rails-5.2.x
+      gemfile: gemfiles/rails-5.2.rb
   fast_finish: true
 
 # We want to use `sudo: false` because the container infrastructure is supposed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 ```
 Ben Johnson <bjohnson@binarylogic.com>,
-Tieg Zaharia <tieg.zaharia@gmail.com>
+Tieg Zaharia <tieg.zaharia@gmail.com>,
 Jared Beck <jared@jaredbeck.com>
 ```
 
@@ -33,14 +33,14 @@ ruby. See `required_ruby_version` in the gemspec.
 Tests can be run against different versions of Rails:
 
 ```
-BUNDLE_GEMFILE=gemfiles/Gemfile.rails-4.2.x bundle install
-BUNDLE_GEMFILE=gemfiles/Gemfile.rails-4.2.x bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle install
+BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle exec rake
 ```
 
 To run a single test:
 
 ```
-BUNDLE_GEMFILE=gemfiles/Gemfile.rails-4.2.x \
+BUNDLE_GEMFILE=gemfiles/rails-6.0.rb \
   bundle exec ruby -I test path/to/test.rb
 ```
 
@@ -57,13 +57,13 @@ Running `rake` also runs a linter, rubocop. Contributions must pass both
 the linter and the tests. The linter can be run on its own.
 
 ```
-BUNDLE_GEMFILE=gemfiles/Gemfile.rails-4.2.x bundle exec rubocop
+BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle exec rubocop
 ```
 
 To run the tests without linting, use `rake test`.
 
 ```
-BUNDLE_GEMFILE=gemfiles/Gemfile.rails-4.2.x bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle exec rake test
 ```
 
 ### Version Control Branches

--- a/gemfiles/Gemfile.rails-6.0.x
+++ b/gemfiles/Gemfile.rails-6.0.x
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-gemspec :path => ".."
-
-# TODO: Use actual version number
-gem "activerecord", github: 'rails/rails'
-gem "activesupport", github: 'rails/rails'
-gem 'sqlite3', :platforms => :ruby

--- a/gemfiles/rails-5.2.rb
+++ b/gemfiles/rails-5.2.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
-gemspec :path => ".."
+gemspec path: ".."
 
 gem "activerecord", "~> 5.2.1"
 gem "activesupport", "~> 5.2.1"
-gem 'sqlite3', :platforms => :ruby
+gem "sqlite3", platforms: :ruby

--- a/gemfiles/rails-6.0.rb
+++ b/gemfiles/rails-6.0.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+gemspec path: ".."
+
+# TODO: Use actual version number
+gem "activerecord", github: "rails/rails"
+gem "activesupport", github: "rails/rails"
+gem "sqlite3", platforms: :ruby


### PR DESCRIPTION
By naming the gemfiles with a .rb extension, we automatically
get syntax highlighting, but more importantly, we get linting.