### PR TITLE
Address Rails 5.1 changes to ActiveModel::Dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ cherry-pick it from the stable branch into master.
 * Added
   * None
 * Fixed
-  * None
+  * replace use of 1) <attribute>_changed? with will_save_change_to_<attribute>?,
+    2) <model>.changed? with <model>.has_changes_to_save?, and 3) <attribute>_was?
+    with <attribute>_in_database
 * Dependencies
   * Drop support for rails < 5.2
   * Add support for rails 6.0

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ class User < ApplicationRecord
     length: { maximum: 100 },
     uniqueness: {
       case_sensitive: false,
-      if: :email_changed?
+      if: :will_save_change_to_email?
     }
 
   validates :login,
@@ -245,7 +245,7 @@ class User < ApplicationRecord
     length: { within: 3..100 },
     uniqueness: {
       case_sensitive: false,
-      if: :login_changed?
+      if: :will_save_change_to_login?
     }
 
   validates :password,

--- a/doc/use_normal_rails_validation.md
+++ b/doc/use_normal_rails_validation.md
@@ -41,7 +41,7 @@ validates :email,
   length: { maximum: 100 },
   uniqueness: {
     case_sensitive: false,
-    if: :email_changed?
+    if: :will_save_change_to_email?
   }
 
 validates :login,
@@ -57,7 +57,7 @@ validates :login,
   length: { within: 3..100 },
   uniqueness: {
     case_sensitive: false,
-    if: :login_changed?
+    if: :will_save_change_to_login?
   }
 
 validates :password,

--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -247,8 +247,8 @@ module Authlogic
           private
 
           def crypted_password_to_validate_against(check_against_database)
-            if check_against_database && send("#{crypted_password_field}_changed?")
-              send("#{crypted_password_field}_was")
+            if check_against_database && send("will_save_change_to_#{crypted_password_field}?")
+              send("#{crypted_password_field}_in_database")
             else
               send(crypted_password_field)
             end
@@ -268,8 +268,8 @@ module Authlogic
             salt = nil
             if password_salt_field
               salt =
-                if check_against_database && send("#{password_salt_field}_changed?")
-                  send("#{password_salt_field}_was")
+                if check_against_database && send("will_save_change_to_#{password_salt_field}?")
+                  send("#{password_salt_field}_in_database")
                 else
                   send(password_salt_field)
                 end
@@ -299,7 +299,7 @@ module Authlogic
             ) &&
               (
                 !check_against_database ||
-                !send("#{crypted_password_field}_changed?")
+                !send("will_save_change_to_#{crypted_password_field}?")
               )
           end
 
@@ -309,6 +309,7 @@ module Authlogic
           end
 
           def require_password?
+            # this is _not_ the activemodel changed? method, see below
             new_record? || password_changed? || send(crypted_password_field).blank?
           end
 

--- a/lib/authlogic/acts_as_authentic/perishable_token.rb
+++ b/lib/authlogic/acts_as_authentic/perishable_token.rb
@@ -58,7 +58,7 @@ module Authlogic
             extend ClassMethods
             include InstanceMethods
 
-            validates_uniqueness_of :perishable_token, if: :perishable_token_changed?
+            validates_uniqueness_of :perishable_token, if: :will_save_change_to_perishable_token?
             before_save :reset_perishable_token, unless: :disable_perishable_token_maintenance?
           end
         end

--- a/lib/authlogic/acts_as_authentic/persistence_token.rb
+++ b/lib/authlogic/acts_as_authentic/persistence_token.rb
@@ -27,7 +27,7 @@ module Authlogic
             end
 
             validates_presence_of :persistence_token
-            validates_uniqueness_of :persistence_token, if: :persistence_token_changed?
+            validates_uniqueness_of :persistence_token, if: :will_save_change_to_persistence_token?
 
             before_validation :reset_persistence_token, if: :reset_persistence_token?
           end

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -116,7 +116,7 @@ module Authlogic
             session_class.activated? &&
             maintain_session? &&
             !session_ids.blank? &&
-            persistence_token_changed?
+            will_save_change_to_persistence_token?
         end
 
         def maintain_session?
@@ -176,7 +176,7 @@ module Authlogic
         end
 
         def log_in_after_password_change?
-          persistence_token_changed? && self.class.log_in_after_password_change
+          will_save_change_to_persistence_token? && self.class.log_in_after_password_change
         end
       end
     end

--- a/lib/authlogic/acts_as_authentic/single_access_token.rb
+++ b/lib/authlogic/acts_as_authentic/single_access_token.rb
@@ -43,7 +43,9 @@ module Authlogic
 
           klass.class_eval do
             include InstanceMethods
-            validates_uniqueness_of :single_access_token, if: :single_access_token_changed?
+            validates_uniqueness_of :single_access_token,
+              if: :will_save_change_to_single_access_token?
+
             before_validation :reset_single_access_token, if: :reset_single_access_token?
             if respond_to?(:after_password_set)
               after_password_set(

--- a/lib/authlogic/session/callbacks.rb
+++ b/lib/authlogic/session/callbacks.rb
@@ -19,7 +19,7 @@ module Authlogic
     #   before_persisting
     #   persist
     #   after_persisting
-    #   [save record if record.changed?]
+    #   [save record if record.has_changes_to_save?]
     #
     #   before_validation
     #   before_validation_on_create
@@ -28,7 +28,7 @@ module Authlogic
     #   after_validation_on_update
     #   after_validation_on_create
     #   after_validation
-    #   [save record if record.changed?]
+    #   [save record if record.has_changes_to_save?]
     #
     #   before_save
     #   before_create
@@ -36,13 +36,13 @@ module Authlogic
     #   after_update
     #   after_create
     #   after_save
-    #   [save record if record.changed?]
+    #   [save record if record.has_changes_to_save?]
     #
     #   before_destroy
-    #   [save record if record.changed?]
+    #   [save record if record.has_changes_to_save?]
     #   after_destroy
     #
-    # Notice the "save record if changed?" lines above. This helps with performance. If
+    # Notice the "save record if has_changes_to_save" lines above. This helps with performance. If
     # you need to make changes to the associated record, there is no need to save the
     # record, Authlogic will do it for you. This allows multiple modules to modify the
     # record and execute as few queries as possible.
@@ -135,7 +135,7 @@ module Authlogic
 
       def save_record(alternate_record = nil)
         r = alternate_record || record
-        if r&.changed? && !r.readonly?
+        if r&.has_changes_to_save? && !r.readonly?
           r.save_without_session_maintenance(validate: false)
         end
       end

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -140,15 +140,15 @@ module ActsAsAuthenticTest
 
     def test_reset_password_in_after_save
       lumbergh = admins(:lumbergh)
-
-      old_perishable_token = lumbergh.perishable_token
       old_crypted_password = lumbergh.crypted_password
-
       lumbergh.role = "Stapler Supervisor"
       lumbergh.save!
-
-      assert_not_equal old_perishable_token, lumbergh.perishable_token
+      # Because his `role` changed, the `after_save` callback in admin.rb will
+      # reset Lumbergh's password.
       assert_not_equal old_crypted_password, lumbergh.crypted_password
+      # Lumbergh's perishable_token has also changed, but that's not relevant
+      # to this test because perishable_token always changes whenever you save
+      # anything (unless you `disable_perishable_token_maintenance`).
     end
 
     private

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -138,6 +138,19 @@ module ActsAsAuthenticTest
       assert_not_equal old_password_salt, ben.password_salt
     end
 
+    def test_reset_password_in_after_save
+      lumbergh = admins(:lumbergh)
+
+      old_perishable_token = lumbergh.perishable_token
+      old_crypted_password = lumbergh.crypted_password
+
+      lumbergh.role = "Stapler Supervisor"
+      lumbergh.save!
+
+      assert_not_equal old_perishable_token, lumbergh.perishable_token
+      assert_not_equal old_crypted_password, lumbergh.crypted_password
+    end
+
     private
 
     def transition_password_to(

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -1,0 +1,8 @@
+lumbergh:
+  login: lumbergh
+  crypted_password: <%= Authlogic::CryptoProviders::SCrypt.encrypt("lumberghrocks") %>
+  password_salt: <%= salt = Authlogic::Random.hex_token %>
+  persistence_token: e3d853f5aa0dacac5c257d03c4e097a3a7f51b182a8fc4f62096d05e939b019855aff0290157ac854e4195f13284ff5223f1996d0fd073e7e360171de54db278
+  perishable_token: <%= Authlogic::Random.friendly_token %>
+  email: lumbergh@initech.com
+  role: TPS Supervisor

--- a/test/libs/admin.rb
+++ b/test/libs/admin.rb
@@ -1,24 +1,23 @@
 # frozen_string_literal: true
 
+# This model demonstrates an `after_save` callback.
 class Admin < ActiveRecord::Base
-  acts_as_authentic do |c|
-    c.transition_from_crypto_providers Authlogic::CryptoProviders::Sha512
-  end
+  acts_as_authentic
+
+  validates :password, confirmation: true
 
   after_save do
+    # In rails 5.1 `role_changed?` was deprecated in favor of `saved_change_to_role?`.
+    #
+    # > DEPRECATION WARNING: The behavior of `attribute_changed?` inside of
+    # > after callbacks will be changing in the next version of Rails.
+    # > The new return value will reflect the behavior of calling the method
+    # > after `save` returned (e.g. the opposite of what it returns now). To
+    # > maintain the current behavior, use `saved_change_to_attribute?` instead.
+    #
+    # So, in rails >= 5.2, we must use `saved_change_to_role?`.
     if saved_change_to_role?
       reset_password!
     end
-  end
-
-  after_save do
-    if saved_change_to_crypted_password
-      reset_perishable_token!
-    end
-  end
-
-  def reset_password!
-    self.password = "1#{SecureRandom.hex}a"
-    save!
   end
 end

--- a/test/libs/admin.rb
+++ b/test/libs/admin.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Admin < ActiveRecord::Base
+  acts_as_authentic do |c|
+    c.transition_from_crypto_providers Authlogic::CryptoProviders::Sha512
+  end
+
+  after_save do
+    if saved_change_to_role?
+      reset_password!
+    end
+  end
+
+  after_save do
+    if saved_change_to_crypted_password
+      reset_perishable_token!
+    end
+  end
+
+  def reset_password!
+    self.password = "1#{SecureRandom.hex}a"
+    save!
+  end
+end

--- a/test/libs/admin_session.rb
+++ b/test/libs/admin_session.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class AdminSession < Authlogic::Session::Base
+end

--- a/test/libs/user.rb
+++ b/test/libs/user.rb
@@ -28,7 +28,7 @@ class User < ActiveRecord::Base
     length: { maximum: 100 },
     uniqueness: {
       case_sensitive: false,
-      if: :email_changed?
+      if: :will_save_change_to_email?
     }
 
   validates :login,
@@ -44,7 +44,7 @@ class User < ActiveRecord::Base
     length: { within: 3..100 },
     uniqueness: {
       case_sensitive: false,
-      if: :login_changed?
+      if: :will_save_change_to_login?
     }
 
   validates :password,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -107,6 +107,18 @@ ActiveRecord::Schema.define(version: 1) do
     t.string    :ldap_login
     t.string    :persistence_token
   end
+
+  create_table :admins do |t|
+    t.datetime  :created_at
+    t.datetime  :updated_at
+    t.string    :login
+    t.string    :crypted_password
+    t.string    :password_salt
+    t.string    :persistence_token
+    t.string    :perishable_token
+    t.string    :email
+    t.string    :role
+  end
 end
 
 require "English"
@@ -127,6 +139,7 @@ require "libs/ldaper"
 require "libs/user"
 require "libs/user_session"
 require "libs/company"
+require "libs/admin"
 
 module ActiveSupport
   class TestCase
@@ -164,7 +177,8 @@ module ActiveSupport
         Ldaper,
         User,
         UserSession,
-        Company
+        Company,
+        Admin
       ].each do |model|
         unless model.respond_to?(:original_acts_as_authentic_config)
           model.class_attribute :original_acts_as_authentic_config
@@ -182,7 +196,8 @@ module ActiveSupport
         Ldaper,
         User,
         UserSession,
-        Company
+        Company,
+        Admin
       ].each do |model|
         model.acts_as_authentic_config = model.original_acts_as_authentic_config
       end


### PR DESCRIPTION
In Rails 5.1, new methods were added that split dirty attribute tracking into _before_ save and _after_ save versions.  Before save, you have will_save_change_to_<attribute>? and in after save you have saved_change_to_<attribute>?, there are a lot of these methods and in Rails 5.2 the behavior of accessing a <attribute>_changed? method or <record>_changed? in an after callback is changed to be the opposite behavior of what it is now.  Rails 5.1 added deprecation warnings for these.

- replace calls to activemodel defined <attribute>_changed? and <attribute>_was?  methods with will_save_change_to_<attribute>? and <attribute_in_database>

Commit in Rails:
https://github.com/rails/rails/commit/16ae3db5a5c6a08383b974ae6c96faac5b4a3c81
