### PR TITLE
Stricter linting of metrics cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,11 +49,6 @@ Metrics/AbcSize:
     # crypto_providers/wordpress is deprecated so we will not attempt to
     # improve its quality.
     - lib/authlogic/crypto_providers/wordpress.rb
-    # After consolidating the 23 session modules into one file (see discussion
-    # in https://github.com/binarylogic/authlogic/pull/642) some methods are
-    # too big. This is a temporary exclusion. This would be an entry in
-    # `.rubocop_todo.yml` if rubocop allowed `Exclude`s in both simultaneously.
-    - 'lib/authlogic/session/base.rb'
     # In an ideal world tests would be held to the same ABC metric as production
     # code. In practice, time spent doing so is not nearly as valuable as
     # spending the same time improving production code.
@@ -72,11 +67,6 @@ Metrics/CyclomaticComplexity:
     # crypto_providers/wordpress is deprecated so we will not attempt to
     # improve its quality.
     - lib/authlogic/crypto_providers/wordpress.rb
-    # After consolidating the 23 session modules into one file (see discussion
-    # in https://github.com/binarylogic/authlogic/pull/642) some methods are
-    # too big. This is a temporary exclusion. This would be an entry in
-    # `.rubocop_todo.yml` if rubocop allowed `Exclude`s in both simultaneously.
-    - 'lib/authlogic/session/base.rb'
 
 # Aim for 80, but 100 is OK.
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,12 +10,6 @@
 Metrics/AbcSize:
   Max: 17.07
 
-# After consolidating the 23 session modules into one file (see discussion in
-# https://github.com/binarylogic/authlogic/pull/642) some methods are too big.
-Metrics/PerceivedComplexity:
-  Exclude:
-    - 'lib/authlogic/session/base.rb'
-
 # Offense count: 5
 Style/ClassVars:
   Exclude:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,14 +33,14 @@ ruby. See `required_ruby_version` in the gemspec.
 Tests can be run against different versions of Rails:
 
 ```
-BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle install
-BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle exec rake
+BUNDLE_GEMFILE=gemfiles/rails_6.0.rb bundle install
+BUNDLE_GEMFILE=gemfiles/rails_6.0.rb bundle exec rake
 ```
 
 To run a single test:
 
 ```
-BUNDLE_GEMFILE=gemfiles/rails-6.0.rb \
+BUNDLE_GEMFILE=gemfiles/rails_6.0.rb \
   bundle exec ruby -I test path/to/test.rb
 ```
 
@@ -57,13 +57,13 @@ Running `rake` also runs a linter, rubocop. Contributions must pass both
 the linter and the tests. The linter can be run on its own.
 
 ```
-BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle exec rubocop
+BUNDLE_GEMFILE=gemfiles/rails_6.0.rb bundle exec rubocop
 ```
 
 To run the tests without linting, use `rake test`.
 
 ```
-BUNDLE_GEMFILE=gemfiles/rails-6.0.rb bundle exec rake test
+BUNDLE_GEMFILE=gemfiles/rails_6.0.rb bundle exec rake test
 ```
 
 ### Version Control Branches

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -1067,6 +1067,7 @@ module Authlogic
       # Constructor
       # ===========
 
+      # rubocop:disable Metrics/AbcSize
       def initialize(*args)
         @id = nil
         self.scope = self.class.scope
@@ -1092,6 +1093,7 @@ module Authlogic
         instance_variable_set("@#{password_field}", nil)
         self.credentials = args
       end
+      # rubocop:enable Metrics/AbcSize
 
       # Public instance methods
       # =======================
@@ -1170,6 +1172,8 @@ module Authlogic
       # # Finally, there's priority_record
       # [{ priority_record: my_object }, :my_id]
       # ```
+      #
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def credentials=(value)
         normalized = Array.wrap(value)
         if normalized.first.class.name == "ActionController::Parameters"
@@ -1225,6 +1229,7 @@ module Authlogic
         values = value.is_a?(Array) ? value : [value]
         self.priority_record = values[1] if values[1].class < ::ActiveRecord::Base
       end
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       # Clears all errors and the associated record, you should call this
       # terminate a session, thus requiring the user to authenticate again if


### PR DESCRIPTION
Disable metrics cops in specific parts of file, instead of entire file.