### PR TITLE
Session::Base#credentials should always return hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ cherry-pick it from the stable branch into master.
       inlined and deleted. This only affects you if you were re-opening
       ("monkey-patching") one of the deleted modules, in which case you can
       re-open `Base` instead.
+    * `Session::Base#credentials` now always returns a hash.
 * Added
   * None
 * Fixed

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -1126,23 +1126,21 @@ module Authlogic
           )
       end
 
-      # The credentials you passed to create your session. See credentials= for
-      # more info.
+      # The credentials you passed to create your session, in a redacted format
+      # intended for output (debugging, logging). See credentials= for more
+      # info.
+      #
+      # @api private
       def credentials
         if authenticating_with_unauthorized_record?
-          # Returning meaningful credentials
-          details = {}
-          details[:unauthorized_record] = "<protected>"
-          details
+          { unauthorized_record: "<protected>" }
         elsif authenticating_with_password?
-          # Returns the login_field / password_field credentials combination in
-          # hash form.
-          details = {}
-          details[login_field.to_sym] = send(login_field)
-          details[password_field.to_sym] = "<protected>"
-          details
+          {
+            login_field.to_sym => send(login_field),
+            password_field.to_sym => "<protected>"
+          }
         else
-          []
+          {}
         end
       end
 

--- a/test/session_test/cookies_test.rb
+++ b/test/session_test/cookies_test.rb
@@ -98,6 +98,12 @@ module SessionTest
       def test_credentials
         session = UserSession.new
         session.credentials = { remember_me: true }
+        assert_equal({}, session.credentials)
+      end
+
+      def test_credentials_assignment
+        session = UserSession.new
+        session.credentials = { remember_me: true }
         assert_equal true, session.remember_me
       end
 


### PR DESCRIPTION
This is the type of problem that we didn't notice because `#credentials`
was split among different files. Now that it's all in one place, the problem
becomes obvious.