### PR TITLE
Fix Rails case_insensitive_comparison change API

### DIFF
--- a/gemfiles/rails_6.0.rb
+++ b/gemfiles/rails_6.0.rb
@@ -3,8 +3,9 @@
 source "https://rubygems.org"
 gemspec path: ".."
 
-# TODO: Use actual version number
-gem "activemodel", github: "rails/rails"
-gem "activerecord", github: "rails/rails"
-gem "activesupport", github: "rails/rails"
+# Rails 6 beta 1 has been released, so you might expect us to use exactly that
+# version here, but it is still in flux, so we may continue using git for a
+# while, maybe until RC 1 is released.
+gem "activerecord", github: "rails/rails", ref: "ebdaa04"
+gem "activesupport", github: "rails/rails", ref: "ebdaa04"
 gem "sqlite3", platforms: :ruby

--- a/gemfiles/rails_6.0.rb
+++ b/gemfiles/rails_6.0.rb
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 # TODO: Use actual version number
+gem "activemodel", github: "rails/rails"
 gem "activerecord", github: "rails/rails"
 gem "activesupport", github: "rails/rails"
 gem "sqlite3", platforms: :ruby

--- a/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
+++ b/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
@@ -34,17 +34,28 @@ module Authlogic
 
         # @api private
         def insensitive_comparison
-          @model_class.connection.case_insensitive_comparison(
-            @model_class.arel_table,
-            @field,
-            @model_class.columns_hash[@field],
-            @value
-          )
+          if AR_GEM_VERSION > Gem::Version.new("5.3")
+            @model_class.connection.case_insensitive_comparison(
+              @model_class.arel_table[@field], @value
+            )
+          else
+            @model_class.connection.case_insensitive_comparison(
+              @model_class.arel_table,
+              @field,
+              @model_class.columns_hash[@field],
+              @value
+            )
+          end
         end
 
         # @api private
+        # rubocop:disable Metrics/AbcSize
         def sensitive_comparison
-          if AR_GEM_VERSION >= Gem::Version.new("5.0")
+          if AR_GEM_VERSION > Gem::Version.new("5.3")
+            @model_class.connection.case_sensitive_comparison(
+              @model_class.arel_table[@field], @value
+            )
+          elsif AR_GEM_VERSION >= Gem::Version.new("5.0")
             @model_class.connection.case_sensitive_comparison(
               @model_class.arel_table,
               @field,
@@ -56,6 +67,7 @@ module Authlogic
             @model_class.arel_table[@field].eq(value)
           end
         end
+        # rubocop:enable Metrics/AbcSize
       end
     end
   end


### PR DESCRIPTION
After some change in API 
https://github.com/rails/rails/blob/e4213e7c682f2b4bf19383ea1af1681c81c96ac5/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb  we receive error 