### PR TITLE
Tests: Fix gem activation issue re: sqlite3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ gemfile:
   - gemfiles/rails_6.0.rb
 
 matrix:
+  allow_failures:
+    # Rails 6 is in beta and they're still making breaking changes.
+    # When rails 6 final is released, we'll remove this `allow_failures`.
+    - gemfile: gemfiles/rails_6.0.rb
   exclude:
     # rails 6 requires ruby >= 2.5.0
     - rvm: 2.3.8

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@
 
 source "https://rubygems.org"
 gemspec
-
-gem "sqlite3", platforms: :ruby

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -34,6 +34,7 @@ require "authlogic/version"
   s.add_development_dependency "byebug", "~> 10.0"
   s.add_development_dependency "minitest-reporters", "~> 1.3"
   s.add_development_dependency "rubocop", "~> 0.62.0"
+  s.add_development_dependency "sqlite3", "~> 1.3.13"
   s.add_development_dependency "timecop", "~> 0.7"
 
   # To reduce gem size, only the minimum files are included.

--- a/gemfiles/rails_5.2.rb
+++ b/gemfiles/rails_5.2.rb
@@ -5,4 +5,3 @@ gemspec path: ".."
 
 gem "activerecord", "~> 5.2.1"
 gem "activesupport", "~> 5.2.1"
-gem "sqlite3", platforms: :ruby

--- a/gemfiles/rails_6.0.rb
+++ b/gemfiles/rails_6.0.rb
@@ -6,4 +6,3 @@ gemspec path: ".."
 # TODO: Use actual version number
 gem "activerecord", github: "rails/rails"
 gem "activesupport", github: "rails/rails"
-gem "sqlite3", platforms: :ruby


### PR DESCRIPTION
```
/home/travis/.rvm/gems/ruby-2.3.8/gems/bundler-2.0.1/lib/bundler/rubygems_integration.rb:408:in `block (2 levels) in replace_gem': Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? can't activate sqlite3 (~> 1.3.6), already activated sqlite3-1.4.0. Make sure all dependencies are added to Gemfile. (LoadError)
```