### PR TITLE
add case-sensitive login tests

### DIFF
--- a/test/acts_as_authentic_test/login_test.rb
+++ b/test/acts_as_authentic_test/login_test.rb
@@ -16,10 +16,12 @@ module ActsAsAuthenticTest
     end
 
     def test_find_by_smart_case_login_field
+      # Note that in the testing library, User#login is configured to be
+      # case-sensitive, but Employee#email is case-insensitive
       ben = users(:ben)
       assert_equal ben, User.find_by_smart_case_login_field("bjohnson")
-      assert_equal ben, User.find_by_smart_case_login_field("BJOHNSON")
-      assert_equal ben, User.find_by_smart_case_login_field("Bjohnson")
+      assert_equal nil, User.find_by_smart_case_login_field("BJOHNSON")
+      assert_equal nil, User.find_by_smart_case_login_field("Bjohnson")
 
       drew = employees(:drew)
       assert_equal drew, Employee.find_by_smart_case_login_field("dgainor@binarylogic.com")

--- a/test/libs/user.rb
+++ b/test/libs/user.rb
@@ -53,8 +53,7 @@ class User < ActiveRecord::Base
     },
     length: { within: 3..100 },
     uniqueness: {
-      case_sensitive: false,
-      if: :will_save_change_to_login?
+      case_sensitive: true
     }
 
   validates :password,


### PR DESCRIPTION
Specifying a case-sensitive field for testing, which should help with #654 and #655.