### PR TITLE
Fix deprecation warning with validates_uniqueness_of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added
   * None
 * Fixed
+  * [#665](https://github.com/binarylogic/authlogic/pull/665) -
+    Explicitly set case_sensitive: true for validates_uniqueness_of validation
+    due to deprecation in Rails 6.0
   * [#659](https://github.com/binarylogic/authlogic/pull/659) -
     Fixed an issue affecting case-sensitive searches in MySQL
 

--- a/lib/authlogic/acts_as_authentic/perishable_token.rb
+++ b/lib/authlogic/acts_as_authentic/perishable_token.rb
@@ -58,7 +58,8 @@ module Authlogic
             extend ClassMethods
             include InstanceMethods
 
-            validates_uniqueness_of :perishable_token, if: :will_save_change_to_perishable_token?
+            validates_uniqueness_of :perishable_token, case_sensitive: true,
+                                                       if: :will_save_change_to_perishable_token?
             before_save :reset_perishable_token, unless: :disable_perishable_token_maintenance?
           end
         end

--- a/lib/authlogic/acts_as_authentic/persistence_token.rb
+++ b/lib/authlogic/acts_as_authentic/persistence_token.rb
@@ -27,7 +27,8 @@ module Authlogic
             end
 
             validates_presence_of :persistence_token
-            validates_uniqueness_of :persistence_token, if: :will_save_change_to_persistence_token?
+            validates_uniqueness_of :persistence_token, case_sensitive: true,
+                                                        if: :will_save_change_to_persistence_token?
 
             before_validation :reset_persistence_token, if: :reset_persistence_token?
           end

--- a/lib/authlogic/acts_as_authentic/single_access_token.rb
+++ b/lib/authlogic/acts_as_authentic/single_access_token.rb
@@ -41,6 +41,7 @@ module Authlogic
           klass.class_eval do
             include InstanceMethods
             validates_uniqueness_of :single_access_token,
+              case_sensitive: true,
               if: :will_save_change_to_single_access_token?
 
             before_validation :reset_single_access_token, if: :reset_single_access_token?


### PR DESCRIPTION
Fix DEPRECATION WARNING: Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1. To continue case sensitive comparison on the :persistence_token attribute in User model, pass `case_sensitive: true` option explicitly to the uniqueness validator.