### PR TITLE
Allow configuring crypto_providers with Strings

### DIFF
--- a/lib/authlogic/acts_as_authentic/password.rb
+++ b/lib/authlogic/acts_as_authentic/password.rb
@@ -113,7 +113,9 @@ module Authlogic
         # * <tt>Accepts:</tt> Class
         def crypto_provider(value = nil)
           CryptoProviders::Guidance.new(value).impart_wisdom
-          rw_config(:crypto_provider, value, CryptoProviders::SCrypt)
+          CryptoProviders.crypto_providers_from(
+            rw_config(:crypto_provider, value, "Authlogic::CryptoProviders::SCrypt")
+          )
         end
         alias crypto_provider= crypto_provider
 
@@ -135,10 +137,12 @@ module Authlogic
         # * <tt>Default:</tt> nil
         # * <tt>Accepts:</tt> Class or Array
         def transition_from_crypto_providers(value = nil)
-          rw_config(
-            :transition_from_crypto_providers,
-            (!value.nil? && [value].flatten.compact) || value,
-            []
+          CryptoProviders.crypto_providers_from(
+            rw_config(
+              :transition_from_crypto_providers,
+              (!value.nil? && [value].flatten.compact) || value,
+              []
+            )
           )
         end
         alias transition_from_crypto_providers= transition_from_crypto_providers
@@ -334,11 +338,11 @@ module Authlogic
           end
 
           def crypto_provider
-            self.class.crypto_provider
+            CryptoProviders.crypto_providers_from(self.class.crypto_provider)
           end
 
           def transition_from_crypto_providers
-            self.class.transition_from_crypto_providers
+            CryptoProviders.crypto_providers_from(self.class.transition_from_crypto_providers)
           end
         end
       end

--- a/lib/authlogic/crypto_providers.rb
+++ b/lib/authlogic/crypto_providers.rb
@@ -83,5 +83,18 @@ module Authlogic
         end
       end
     end
+
+    # Convert a string constant into a class.
+    def self.crypto_provider_from(value)
+      value.is_a?(String) ? value.constantize : value
+    end
+
+    # Convert an array of string constants into an array of classes.
+    def self.crypto_providers_from(value)
+      if value.is_a?(Array)
+        return value.map { |provider| CryptoProviders.crypto_provider_from(provider) }
+      end
+      CryptoProviders.crypto_provider_from(value)
+    end
   end
 end

--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -67,6 +67,30 @@ module ActsAsAuthenticTest
       assert_equal [], User.transition_from_crypto_providers
     end
 
+    def test_crypto_provider_config_with_string
+      assert_equal Authlogic::CryptoProviders::SCrypt, User.crypto_provider
+      silence_warnings do
+        User.crypto_provider = "Authlogic::CryptoProviders::BCrypt"
+      end
+      assert_equal Authlogic::CryptoProviders::BCrypt, User.crypto_provider
+      silence_warnings do
+        User.crypto_provider "Authlogic::CryptoProviders::Sha512"
+      end
+      assert_equal Authlogic::CryptoProviders::Sha512, User.crypto_provider
+    end
+
+    def test_transition_from_crypto_providers_config_with_strings
+      assert_equal [Authlogic::CryptoProviders::Sha512], User.transition_from_crypto_providers
+      assert_equal [], Employee.transition_from_crypto_providers
+
+      User.transition_from_crypto_providers = ["Authlogic::CryptoProviders::BCrypt",
+                                               "Authlogic::CryptoProviders::Sha512"]
+      assert_equal [Authlogic::CryptoProviders::BCrypt, Authlogic::CryptoProviders::Sha512],
+        User.transition_from_crypto_providers
+      User.transition_from_crypto_providers []
+      assert_equal [], User.transition_from_crypto_providers
+    end
+
     def test_password
       u = User.new
       old_password_salt = u.password_salt


### PR DESCRIPTION
In order to prevent autoloading SCrypt before config is applied, I want to use Strings to configure the default crypto_provider. 

### Expected Behavior

When I use authlogic 3.4.0+ on linux with a grsec kernel, it should not RuntimeError.

### Actual Behavior

For example, running with authlogic on an Ubuntu 4.14.93-grsec-grsec+ results in a RuntimeError.

The method `acts_as_authentic` takes a block to allow configuration. When this is done the method `crypto_provider` will be called. The method signature contains a default argument with value of `CryptoProviders::SCrypt`. 

See: https://github.com/mihael/authlogic/blob/master/lib/authlogic/acts_as_authentic/password.rb#L116

When this happens SCrypt lib will load and the following lines are executed:

`attach_function :sc_calibrate, [:size_t, :double, :double, :pointer], :int, :blocking => true`

See: https://github.com/pbhogan/scrypt/blob/v3.0.6/lib/scrypt.rb#L14

Which then fails with a RuntimeError in the `attach` function in the ffi lib.

The ffi lib states:

> On Linux systems running with PaX (Gentoo, Alpine, etc.), FFI may trigger mprotect errors. You may need to disable mprotect for ruby (paxctl -m [/path/to/ruby]) for the time being until a solution is found.

So, if we simply try to configure BCrypt inside `acts_as_authentic` block, we will still load and run the SCrypt lib, and thus fail and the server will not work.

```
acts_as_authentic do |c|
    c.crypto_provider = Authlogic::CryptoProviders::BCrypt # <= failing with RuntimeError
end
```

### Solution

Initially I worked around this by using BCrypt as the default value passed in the method. But then created this PR to have a better way to configure authlogic, so it would not load SCrypt prior to configuring. This PR does a bit of refactoring to allow passing String instead of Class for the default value of crypto_provider, thus avoiding the autoload.

With this code I can run authlogic on grsec kernels, since SCrypt will not autoload during runtime (assuming another provider was configured, like BCrypt, since SCrypt obviously can't work on grsec due to ffi limitation).

Extra context:
https://github.com/technion/ruby-argon2/issues/15
https://github.com/ffi/ffi/issues/578