### PR TITLE
Update table of activerecord versions supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ tools your framework provides in the controller object.
 | 4.4     | 4-4-stable   | >= 2.3.0 | >= 4.2, < 5.3 |
 | 4.3     | 4-3-stable   | >= 2.3.0 | >= 4.2, < 5.3 |
 | 4.2     | 4-2-stable   | >= 2.2.0 | >= 4.2, < 5.3 |
-| 3       | 3-stable     | >= 1.9.3 | >= 3.2, < 5.2 |
+| 3       | 3-stable     | >= 1.9.3 | >= 3.2, < 5.3 |
 | 2       | rails2       | >= 1.9.3 | ~> 2.3.0      |
 | 1       | ?            | ?        | ?             |
 


### PR DESCRIPTION
I was looking to update to rails 5.2 and wanted to check if this was
supported on the version 3 of the branch. According to
https://github.com/binarylogic/authlogic/pull/582
Rails 5.2 is supported now on Authlogic v 3, so, updating the table
accordingly.

Also updating the version identifiers to be <= 5.2 etc. as 5.3 doesn't
exist.