### PR TITLE
Delete AuthlogicLoadedTooLateError

### DIFF
--- a/lib/authlogic/controller_adapters/rails_adapter.rb
+++ b/lib/authlogic/controller_adapters/rails_adapter.rb
@@ -7,20 +7,6 @@ module Authlogic
     # Similar to how ActiveRecord has an adapter for MySQL, PostgreSQL, SQLite,
     # etc.
     class RailsAdapter < AbstractAdapter
-      # :nodoc:
-      class AuthlogicLoadedTooLateError < StandardError
-        def message
-          <<~EOS.squish
-            Authlogic is trying to add a callback to ActionController::Base but
-            ApplicationController has already been loaded, so the callback won't
-            be copied into your application. Generally this is due to another
-            gem or plugin requiring your ApplicationController prematurely, such
-            as the resource_controller plugin. Please require Authlogic first,
-            before these other gems / plugins.
-          EOS
-        end
-      end
-
       def authenticate_with_http_basic(&block)
         controller.authenticate_with_http_basic(&block)
       end
@@ -43,16 +29,7 @@ module Authlogic
       # "activates" authlogic.
       module RailsImplementation
         def self.included(klass) # :nodoc:
-          if defined?(::ApplicationController)
-            raise AuthlogicLoadedTooLateError
-          end
-
-          # In Rails 4.0.2, the *_filter methods were renamed to *_action.
-          if klass.respond_to? :prepend_before_action
-            klass.prepend_before_action :activate_authlogic
-          else
-            klass.prepend_before_filter :activate_authlogic
-          end
+          klass.prepend_before_action :activate_authlogic
         end
 
         private


### PR DESCRIPTION
This error no longer seems to be necessary.

I tested this in a new rails 6.0.0 application. In the following,
my debug output is prefixed with "->".

```
bin/rails server
-> loading rails_adapter.rb
=> Booting Puma
...
* Listening on tcp://localhost:3000
...
-> RailsImplementation included into ActionController::Base
-> RailsImplementation included into ActionController::API
-> loading application_controller.rb
Started GET "/" for 127.0.0.1 at 2019-09-11 13:33:05 -0400
Processing by HomeController#index as HTML
-> activate_authlogic
  Rendering home/index.html.erb within layouts/application
```

We can see that the `activate_authlogic` callback still occurs. So,
raising an AuthlogicLoadedTooLateError would be incorrect.

And, of course, I tested a normal sign in POST.