### PR TITLE
Use cookies only when available

### DIFF
--- a/lib/authlogic/controller_adapters/rails_adapter.rb
+++ b/lib/authlogic/controller_adapters/rails_adapter.rb
@@ -14,7 +14,7 @@ module Authlogic
       # Returns a `ActionDispatch::Cookies::CookieJar`. See the AC guide
       # http://guides.rubyonrails.org/action_controller_overview.html#cookies
       def cookies
-        controller.send(:cookies)
+        controller.respond_to?(:cookies, true) ? controller.send(:cookies) : nil
       end
 
       def cookie_domain

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -415,10 +415,10 @@ module Authlogic
       before_save :set_last_request_at
 
       after_save :reset_perishable_token!
-      after_save :save_cookie
+      after_save :save_cookie, if: :cookie_enabled?
       after_save :update_session
 
-      after_destroy :destroy_cookie
+      after_destroy :destroy_cookie, if: :cookie_enabled?
       after_destroy :update_session
 
       # `validate` callbacks, in deliberate order. For example,
@@ -1611,10 +1611,16 @@ module Authlogic
       # @api private
       # @return ::Authlogic::CookieCredentials or if no cookie is found, nil
       def cookie_credentials
+        return unless cookie_enabled?
+
         cookie_value = cookie_jar[cookie_key]
         unless cookie_value.nil?
           ::Authlogic::CookieCredentials.parse(cookie_value)
         end
+      end
+
+      def cookie_enabled?
+        !controller.cookies.nil?
       end
 
       def cookie_jar

--- a/lib/authlogic/test_case.rb
+++ b/lib/authlogic/test_case.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require File.dirname(__FILE__) + "/test_case/rails_request_adapter"
+require File.dirname(__FILE__) + "/test_case/mock_api_controller"
 require File.dirname(__FILE__) + "/test_case/mock_cookie_jar"
 require File.dirname(__FILE__) + "/test_case/mock_controller"
 require File.dirname(__FILE__) + "/test_case/mock_logger"

--- a/lib/authlogic/test_case/mock_api_controller.rb
+++ b/lib/authlogic/test_case/mock_api_controller.rb
@@ -27,7 +27,7 @@ module Authlogic
       end
 
       def request
-        @request ||= MockRequest.new(controller)
+        @request ||= MockRequest.new(self)
       end
 
       def request_content_type
@@ -37,6 +37,16 @@ module Authlogic
       def session
         @session ||= {}
       end
+
+      # If method is defined, it causes below behavior...
+      #   controller = Authlogic::ControllerAdapters::RailsAdapter.new(
+      #     Authlogic::TestCase::MockAPIController.new
+      #   )
+      #   controller.responds_to_single_access_allowed? #=> true
+      #   controller.single_access_allowed?
+      #     #=> NoMethodError: undefined method `single_access_allowed?' for nil:NilClass
+      #
+      undef :single_access_allowed?
     end
   end
 end

--- a/lib/authlogic/test_case/mock_api_controller.rb
+++ b/lib/authlogic/test_case/mock_api_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Authlogic
+  module TestCase
+    # Basically acts like an API controller but doesn't do anything.
+    # Authlogic can interact with this, do it's thing and then you can look at
+    # the controller object to see if anything changed.
+    class MockAPIController < ControllerAdapters::AbstractAdapter
+      attr_writer :request_content_type
+
+      def initialize
+      end
+
+      # Expected API controller has no cookies method.
+      undef :cookies
+
+      def cookie_domain
+        nil
+      end
+
+      def logger
+        @logger ||= MockLogger.new
+      end
+
+      def params
+        @params ||= {}
+      end
+
+      def request
+        @request ||= MockRequest.new(controller)
+      end
+
+      def request_content_type
+        @request_content_type ||= "text/html"
+      end
+
+      def session
+        @session ||= {}
+      end
+    end
+  end
+end

--- a/lib/authlogic/test_case/mock_controller.rb
+++ b/lib/authlogic/test_case/mock_controller.rb
@@ -39,7 +39,7 @@ module Authlogic
       end
 
       def request
-        @request ||= MockRequest.new(controller)
+        @request ||= MockRequest.new(self)
       end
 
       def request_content_type

--- a/lib/authlogic/test_case/mock_request.rb
+++ b/lib/authlogic/test_case/mock_request.rb
@@ -9,6 +9,10 @@ module Authlogic
         self.controller = controller
       end
 
+      def format
+        controller.request_content_type if controller.respond_to? :request_content_type
+      end
+
       def ip
         controller&.respond_to?(:env) &&
           controller.env.is_a?(Hash) &&

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "authlogic/controller_adapters/rails_adapter"
 
 module Authlogic
   module ControllerAdapters
@@ -17,6 +18,16 @@ module Authlogic
         assert controller.params.equal?(adapter.params)
         assert adapter.respond_to?(:an_arbitrary_method)
         assert_equal "bar", adapter.an_arbitrary_method
+      end
+    end
+
+    class RailsAdapterTest < ActiveSupport::TestCase
+      def test_api_controller
+        controller = MockAPIController.new
+        adapter = Authlogic::ControllerAdapters::RailsAdapter.new(controller)
+
+        assert_equal controller, adapter.controller
+        assert_nil adapter.cookies
       end
     end
   end

--- a/test/session_test/persistence_test.rb
+++ b/test/session_test/persistence_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "authlogic/controller_adapters/rails_adapter"
 
 module SessionTest
   class PersistenceTest < ActiveSupport::TestCase
@@ -15,6 +16,20 @@ module SessionTest
       set_session_for(aaron)
       session = UserSession.find
       assert session
+    end
+
+    def test_find_in_api
+      @controller = Authlogic::TestCase::MockAPIController.new
+      UserSession.controller =
+        Authlogic::ControllerAdapters::RailsAdapter.new(@controller)
+
+      aaron = users(:aaron)
+      refute UserSession.find
+
+      UserSession.single_access_allowed_request_types = ["application/json"]
+      set_params_for(aaron)
+      set_request_content_type("application/json")
+      assert UserSession.find
     end
 
     def test_persisting


### PR DESCRIPTION
Because `ActionController::API` does not include `ActionController::Cookies` metal and `ActionDispatch::Cookies` rack module,
Therefore, our controller can not use the `cookies` method.

In this patch, `Authlogic::Session::Base` calls `controller#cookies` only when available.