### PR TITLE
Respect the `log_in_after_create` setting when creating a new user as a logged-out user

### DIFF
--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -176,7 +176,7 @@ module Authlogic
         end
 
         def log_in_after_password_change?
-          will_save_change_to_persistence_token? && self.class.log_in_after_password_change
+          persisted? && will_save_change_to_persistence_token? && self.class.log_in_after_password_change
         end
       end
     end

--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -176,7 +176,8 @@ module Authlogic
         end
 
         def log_in_after_password_change?
-          persisted? && will_save_change_to_persistence_token? && self.class.log_in_after_password_change
+          persisted? && will_save_change_to_persistence_token? &&
+            self.class.log_in_after_password_change
         end
       end
     end

--- a/test/acts_as_authentic_test/session_maintenance_test.rb
+++ b/test/acts_as_authentic_test/session_maintenance_test.rb
@@ -59,6 +59,18 @@ module ActsAsAuthenticTest
       assert_equal logged_in_user, old_user
     end
 
+    def test_no_login_after_logged_out_create
+      User.log_in_after_create = false
+      user = User.create(
+        login: "awesome2",
+        password: "saweeeet2",
+        password_confirmation: "saweeeet2",
+        email: "awesome2@awesome.com"
+      )
+      assert user.persisted?
+      assert_equal UserSession.find, nil
+    end
+
     def test_updating_session_with_failed_magic_state
       ben = users(:ben)
       ben.confirmed = false


### PR DESCRIPTION
There appears to be a bug in how `log_in_after_create` and `log_in_after_password_change` interact when creating a new account.

Repro steps:
- Configure a project so that `log_in_after_create` is `false` and `log_in_after_password_change` is `true`
- As a logged-out user, register for a new account
- You will be logged in immediately, as your password has changed as a part of account creation

This PR updates `log_in_after_password_change` so that it only maintains sessions for accounts that already exist. This allows the `log_in_after_create` setting to properly disable auto-login after new account creation.