### PR TITLE
github: Update issue template and triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,7 @@
 ---
 name: I want to fix a bug, but need some help
 about: >
-  If the bug is easy to reproduce, we will help. However, you must fix the bug,
-  in a reasonable amount of time, or your issue will be closed. See
+  If the bug is easy to reproduce, we will help. See
   CONTRIBUTING.md
 
 ---
@@ -17,8 +16,7 @@ ISSUES THAT DO NOT FOLLOW THIS TEMPLATE WILL BE CLOSED IMMEDIATELY.
     guide](https://github.com/binarylogic/authlogic/blob/master/CONTRIBUTING.md)
     for instructions.
 - [ ] This bug is reproducible with a clean install of authlogic
-- [ ] I am committed to fixing this in a reasonable amount of time, and
-  responding promptly to feedback.
+- [ ] Include the steps to reproduce the bugs
 
 # Expected Behavior
 

--- a/.github/ISSUE_TEMPLATE/feature_proposal.md
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.md
@@ -1,8 +1,7 @@
 ---
 name: Feature Proposal
 about: >
-  Propose something that you would like to build. We'll help, but you must build
-  it yourself, in a reasonable amount of time, or your issue will be closed. See
+  Propose something that you would like to build. See
   CONTRIBUTING.md
 
 ---
@@ -16,14 +15,18 @@ ISSUES THAT DO NOT FOLLOW THIS TEMPLATE WILL BE CLOSED IMMEDIATELY.
   - Do not disclose security issues in public. See our [contributing
     guide](https://github.com/binarylogic/authlogic/blob/master/CONTRIBUTING.md)
     for instructions.
-- [ ] I am committed to implementing this feature in a reasonable amount of
-  time, and responding promptly to feedback.
+
+- [ ] Include the reason why this feature is helpfull for the community
 
 # Current Behavior
 
 Describe.
 
 # Proposed Behavior
+
+Describe.
+
+# Explain why this feature is helpfull
 
 Describe.
 

--- a/.github/triage.md
+++ b/.github/triage.md
@@ -4,11 +4,11 @@ Common responses to issues.
 
 ## Ignored issue template, bug report
 
-Due to limited volunteers, all issues are required to use our [issue template](https://github.com/binarylogic/authlogic/blob/master/.github/ISSUE_TEMPLATE/bug_report.md). Please open a new issue and follow the instructions. We can help, but we require you to take an active leadership role in fixing any issues you identify. If code changes are needed, you can open an issue for discussion, but you must commit to authoring a PR.
+Due to limited volunteers, all issues are required to use our [issue template](https://github.com/binarylogic/authlogic/blob/master/.github/ISSUE_TEMPLATE/bug_report.md). Please open a new issue and follow the instructions. We can help, but we require you to take an active leadership role in fixing any issues you identify. If code changes are needed, you can open an issue for discussion.
 
 ## Usage Question
 
-Due to limited volunteers, we can't accept usage questions. Please ask such questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/authlogic). We don't even have enough volunteers to accept non-security bug reports, unless you can commit to fixing them yourself, and just need some help. If you can commit to fixing a non-security bug yourself, you can open an issue, but please follow our issue template.
+Due to limited volunteers, we can't accept usage questions. Please ask such questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/authlogic). We don't even have enough volunteers to accept non-security bug reports. If you can commit to fixing a non-security bug yourself, you can open an issue, but please follow our issue template.
 
 ## Usage question we were able to answer
 


### PR DESCRIPTION
Why is this helpful?
Allowing reporting bugs is helpful for the community. Obligated to fix the bugs reported will have the possibility to have some bugs left unreported.

Another solution is disable the `issues` feature and depends on  `pull request` solely for bug report.