### PR TITLE
Fix ruby 2.7 warning on kwargs changes:

### DIFF
--- a/lib/authlogic/i18n/translator.rb
+++ b/lib/authlogic/i18n/translator.rb
@@ -8,7 +8,7 @@ module Authlogic
       # arguments, else returns +options[:default]+.
       def translate(key, options = {})
         if defined?(::I18n)
-          ::I18n.translate key, options
+          ::I18n.translate key, **options
         else
           options[:default]
         end


### PR DESCRIPTION
 authlogic/lib/authlogic/i18n/translator.rb:11: warning: The last argument is used as the keyword parameter

Explicit kwargs with double splat to be ruby-2.7 ready