### PR TITLE
email is unique in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ class CreateUser < ActiveRecord::Migration
     create_table :users do |t|
       # Authlogic::ActsAsAuthentic::Email
       t.string    :email
+      t.index     :email, unique: true
 
       # Authlogic::ActsAsAuthentic::Password
       t.string    :crypted_password


### PR DESCRIPTION
Hello

If you allow multiple emails for a user, you will not be able to make it unique when you login, causing problems.

I thought it would be better to explicitlv make it unique, but what about?
