### PR TITLE
Fix typo: longest allowed tld is 25 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * ensure that login field validation uses correct locale (@sskirby)
   * add a respond_to_missing? in AbstractAdapter that also checks controller respond_to?
   * [#561](https://github.com/binarylogic/authlogic/issues/561) authenticates_many now works with scope_cookies:true
-  * Allow tld up to 24 characters per https://data.iana.org/TLD/tlds-alpha-by-domain.txt
+  * Allow tld up to 25 characters per https://data.iana.org/TLD/tlds-alpha-by-domain.txt
 
 ## 3.8.0 2018-02-07
 


### PR DESCRIPTION
The referenced list contains `XN--VERMGENSBERATUNG-PWB` which is 25 characters. The code seems correct and rates a 25 character tld as valid while 26 characters are invalid.