### PR TITLE
Eliminate Ruby 2.7 warnings about keywords arguments usage.

### DIFF
--- a/lib/authlogic/acts_as_authentic/session_maintenance.rb
+++ b/lib/authlogic/acts_as_authentic/session_maintenance.rb
@@ -93,9 +93,9 @@ module Authlogic
         end
 
         # Save the record and skip session maintenance all together.
-        def save_without_session_maintenance(*args)
+        def save_without_session_maintenance(**options)
           self.skip_session_maintenance = true
-          result = save(*args)
+          result = save(**options)
           self.skip_session_maintenance = false
           result
         end


### PR DESCRIPTION
"warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"

Fixes #716