### PR TITLE
Remove db_setup? method to avoid silent failure to load of ActsAsAuth…

### DIFF
--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -31,7 +31,6 @@ module Authlogic
         #
         # See the various sub modules for the configuration they provide.
         def acts_as_authentic
-          return unless db_setup?
           yield self if block_given?
           acts_as_authentic_modules.each { |mod| include mod }
         end
@@ -67,19 +66,10 @@ module Authlogic
 
         private
 
-        def db_setup?
-          column_names
-          true
-        rescue StandardError
-          false
-        end
-
         def first_column_to_exist(*columns_to_check)
-          if db_setup?
-            columns_to_check.each do |column_name|
-              if column_names.include?(column_name.to_s)
-                return column_name.to_sym
-              end
+          columns_to_check.each do |column_name|
+            if column_names.include?(column_name.to_s)
+              return column_name.to_sym
             end
           end
           columns_to_check.first&.to_sym

--- a/test/acts_as_authentic_test/base_test.rb
+++ b/test/acts_as_authentic_test/base_test.rb
@@ -16,12 +16,5 @@ module ActsAsAuthenticTest
         User.acts_as_authentic({})
       end
     end
-
-    def test_acts_as_authentic_with_no_table
-      klass = Class.new(ActiveRecord::Base)
-      assert_nothing_raised do
-        klass.acts_as_authentic
-      end
-    end
   end
 end


### PR DESCRIPTION
Context: When using Authlogic in a distributed environment, a single instance started to log some undefined method errors related to Authlogic modules like:

```
NoMethodError: undefined method `save_without_session_maintenance' for #<User:0x00007f5dae9362d8>
```

Digging into, I've found that the `acts_as_authentic` method will fail to load silently on database connection errors (e.g. `Mysql2::Error::ConnectionError`), something that might have happened on a that specific instance initialization.

In #290 a similar issue was mentioned, but lately the code was reverted because it was causing trouble to run the migrations for first time.

As far as I can tell, this db connectivity and migrations check can cause more harm than good, because you end with more obscure undefined methods in the wrong place at the wrong time.