### PR TITLE
Transitioning password should not set password_changed? true

### DIFF
--- a/test/acts_as_authentic_test/password_test.rb
+++ b/test/acts_as_authentic_test/password_test.rb
@@ -92,6 +92,23 @@ module ActsAsAuthenticTest
       )
     end
 
+    def test_password_changed_false_if_transitioning
+      User.class_eval do
+        after_update :verify_not_changed, unless: :password_changed?
+        def verify_not_changed; end
+      end
+      ben = users(:ben)
+      mock_method = MiniTest::Mock.new
+      mock_method.expect :call, nil
+      ben.stub :verify_not_changed, mock_method do
+        transition_password_to(Authlogic::CryptoProviders::BCrypt, ben)
+      end
+      mock_method.verify
+      User.class_eval do
+        User.skip_callback :update, :after, :verify_not_changed
+      end
+    end
+
     def test_v2_crypto_provider_transition
       ben = users(:ben)
 


### PR DESCRIPTION
If a password is being transitioned to a new crypto provider, I would expect ```password_changed?``` to be falsey, but it is true. This draft PR adds a test to demonstrate it. If you change the definition of ```transition_password``` as follows, the test will pass:
```
def transition_password(attempted_password)
    self.password = attempted_password
+   @password_changed = false
    save(validate: false)
end
```
In password= @password_changed is set to true, so this just inverts that. Other possible solutions I've thought of:
1. don't call password= in transition_password, instead call encrypt right there (and whatever else might be required
2. set a new instance variable @password_transitioned which can be used in conditions like password_changed?