### PR TITLE
Raise an error if database connection is not established before using acts_as_authentic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added
   * [#666](https://github.com/binarylogic/authlogic/pull/666) -
     Forwardported Authlogic::Session::Cookies.encrypt_cookie option
+  * [#723](https://github.com/binarylogic/authlogic/pull/723) -
+    Option to raise a `Authlogic::ModelSetupError` when your database is not
+    configured correctly.
 * Fixed
   * None
 

--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -31,8 +31,8 @@ module Authlogic
         #
         # See the various sub modules for the configuration they provide.
         def acts_as_authentic
-          return unless db_setup?
           yield self if block_given?
+          return unless db_setup?
           acts_as_authentic_modules.each { |mod| include mod }
         end
 
@@ -65,12 +65,27 @@ module Authlogic
           self.acts_as_authentic_modules = modules
         end
 
+        # Some Authlogic modules requires a database connection with a existing
+        # users table by the moment when you call the `acts_as_authentic`
+        # method. If you try to call `acts_as_authentic` without a database
+        # connection, it will raise a `Authlogic::ModelSetupError`.
+        #
+        # If you rely on the User model before the database is setup correctly,
+        # set this field to false.
+        # * <tt>Default:</tt> false
+        # * <tt>Accepts:</tt> Boolean
+        def raise_on_model_setup_error(value = nil)
+          rw_config(:raise_on_model_setup_error, value, false)
+        end
+        alias raise_on_model_setup_error= raise_on_model_setup_error
+
         private
 
         def db_setup?
           column_names
           true
         rescue StandardError
+          raise ModelSetupError if raise_on_model_setup_error
           false
         end
 

--- a/lib/authlogic/errors.rb
+++ b/lib/authlogic/errors.rb
@@ -32,4 +32,19 @@ module Authlogic
       EOS
     end
   end
+
+  # :nodoc:
+  class ModelSetupError < Error
+    def message
+      <<-EOS
+        You must establish a database connection and run the migrations before
+        using acts_as_authentic. If you need to load the User model before the
+        database is set up correctly, please set the following:
+
+            acts_as_authentic do |c|
+              c.raise_on_model_setup_error = false
+            end
+      EOS
+    end
+  end
 end

--- a/test/acts_as_authentic_test/base_test.rb
+++ b/test/acts_as_authentic_test/base_test.rb
@@ -17,11 +17,21 @@ module ActsAsAuthenticTest
       end
     end
 
-    def test_acts_as_authentic_with_no_table
+    def test_acts_as_authentic_with_no_table_raise_on_model_setup_error_default
       klass = Class.new(ActiveRecord::Base)
       assert_nothing_raised do
         klass.acts_as_authentic
       end
+    end
+
+    def test_acts_as_authentic_with_no_table_raise_on_model_setup_error_enabled
+      klass = Class.new(ActiveRecord::Base)
+      e = assert_raises Authlogic::ModelSetupError do
+        klass.acts_as_authentic do |c|
+          c.raise_on_model_setup_error = true
+        end
+      end
+      refute e.message.empty?
     end
   end
 end


### PR DESCRIPTION
Some Authlogic modules requires a database connection with a existing table by the moment when you call the `acts_as_authentic` method. Currently the errors are rescued and some modules will not be included to the User model. Rising a exception will prevent the load of User model without some Authlogic modules. 

If you rely on the User model load before the database is setup correctly (e.g. eager loading on rake tasks), you can disable the error with:
```
acts_as_authentic do |c|
 c.raise_on_database_errors = false
end
```

Fixes #724 