### PR TITLE
Support string cookie values in rails test cases

### DIFF
--- a/lib/authlogic/test_case/mock_cookie_jar.rb
+++ b/lib/authlogic/test_case/mock_cookie_jar.rb
@@ -12,6 +12,7 @@ module Authlogic
       end
 
       def []=(key, options)
+        options = { value: options } unless options.is_a?(Hash)
         (@set_cookies ||= {})[key.to_s] = options
         super
       end
@@ -52,6 +53,7 @@ module Authlogic
       end
 
       def []=(key, options)
+        options = { value: options } unless options.is_a?(Hash)
         options[:value] = "#{options[:value]}--#{Digest::SHA1.hexdigest options[:value]}"
         @parent_jar[key] = options
       end
@@ -75,6 +77,7 @@ module Authlogic
       end
 
       def []=(key, options)
+        options = { value: options } unless options.is_a?(Hash)
         options[:value] = self.class.encrypt(options[:value])
         @parent_jar[key] = options
       end

--- a/lib/authlogic/test_case/rails_request_adapter.rb
+++ b/lib/authlogic/test_case/rails_request_adapter.rb
@@ -12,7 +12,7 @@ module Authlogic
       def cookies
         new_cookies = MockCookieJar.new
         super.each do |key, value|
-          new_cookies[key] = value[:value]
+          new_cookies[key] = cookie_value(value)
         end
         new_cookies
       end
@@ -27,6 +27,12 @@ module Authlogic
 
       def request_content_type
         request.format.to_s
+      end
+
+      private
+
+      def cookie_value(value)
+        value.is_a?(Hash) ? value[:value] : value
       end
     end
   end

--- a/test/adapter_test.rb
+++ b/test/adapter_test.rb
@@ -30,5 +30,26 @@ module Authlogic
         assert_nil adapter.cookies
       end
     end
+
+    class RailsRequestAdapterTest < ActiveSupport::TestCase
+      def test_adapter_with_string_cookie
+        controller = MockController.new
+        controller.cookies["foo"] = "bar"
+        adapter = Authlogic::TestCase::RailsRequestAdapter.new(controller)
+
+        assert adapter.cookies
+      end
+
+      def test_adapter_with_hash_cookie
+        controller = MockController.new
+        controller.cookies["foo"] = {
+          value: "bar",
+          expires: nil
+        }
+        adapter = Authlogic::TestCase::RailsRequestAdapter.new(controller)
+
+        assert adapter.cookies
+      end
+    end
   end
 end

--- a/test/session_test/cookies_test.rb
+++ b/test/session_test/cookies_test.rb
@@ -245,6 +245,28 @@ module SessionTest
         assert session.destroy
         refute controller.cookies["user_credentials"]
       end
+
+      def test_string_cookie
+        payload = "bar"
+        controller.cookies["foo"] = payload
+        assert_equal(payload, controller.cookies["foo"])
+      end
+
+      def test_string_cookie_signed
+        payload = "bar"
+        session = UserSession.new
+        session.sign_cookie = true
+        controller.cookies["foo"] = payload
+        assert_equal(payload, controller.cookies.signed["foo"])
+      end
+
+      def test_string_cookie_encrypted
+        payload = "bar"
+        session = UserSession.new
+        session.encrypt_cookie = true
+        controller.cookies["foo"] = payload
+        assert_equal(payload, controller.cookies.encrypted["foo"])
+      end
     end
   end
 end


### PR DESCRIPTION
In Authlogic v6.2, a new method `cookie_enabled?` started exercising cookie code in test cases in a few more places than usual, resulting in existing test code in downstream projects that included cookies with [string values](https://api.rubyonrails.org/classes/ActionDispatch/Cookies.html) (rather than hash values) to start failing with:
```
TypeError: no implicit conversion of Symbol into Integer
```

This PR adds support for both, using the same approach as [Rails itself](https://github.com/rails/rails/blob/71bc41477da96bb05edc33c1b6a42203e6999667/actionpack/lib/action_dispatch/middleware/cookies.rb#L364-L370).

Before:
![image](https://user-images.githubusercontent.com/6880880/102762915-30be3980-4336-11eb-9091-105621ddc3d9.png)

After:
![image](https://user-images.githubusercontent.com/6880880/102762931-387dde00-4336-11eb-8ee2-027292956beb.png)
