### PR TITLE
Proposed solution for ActiveRecord deprecation in Rails 7.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Style/ClassVars:
     - 'lib/authlogic/i18n.rb'
 
 # Offense count: 4
-Lint/MissingSuper:
+Style/MethodMissingSuper:
   Exclude:
     - 'lib/authlogic/controller_adapters/abstract_adapter.rb'
     - 'lib/authlogic/controller_adapters/sinatra_adapter.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Style/ClassVars:
     - 'lib/authlogic/i18n.rb'
 
 # Offense count: 4
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Exclude:
     - 'lib/authlogic/controller_adapters/abstract_adapter.rb'
     - 'lib/authlogic/controller_adapters/sinatra_adapter.rb'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Please use github issues only for bug reports and feature suggestions.
 ### Usage Questions
 
 Please ask usage questions on
-[stackoverflow](http://stackoverflow.com/questions/tagged/authlogic).
+[Stack Overflow](http://stackoverflow.com/questions/tagged/authlogic).
 
 ## Development
 
@@ -33,8 +33,21 @@ ruby. See `required_ruby_version` in the gemspec.
 Tests can be run against different versions of Rails:
 
 ```
+# Rails 5.2
+BUNDLE_GEMFILE=gemfiles/rails_5.2.rb bundle install
+BUNDLE_GEMFILE=gemfiles/rails_5.2.rb bundle exec rake
+
+# Rails 6.0
 BUNDLE_GEMFILE=gemfiles/rails_6.0.rb bundle install
 BUNDLE_GEMFILE=gemfiles/rails_6.0.rb bundle exec rake
+
+# Rails 6.1
+BUNDLE_GEMFILE=gemfiles/rails_6.1.rb bundle install
+BUNDLE_GEMFILE=gemfiles/rails_6.1.rb bundle exec rake
+
+# Rails 7.0
+BUNDLE_GEMFILE=gemfiles/rails_7.0.rb bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7.0.rb bundle exec rake
 ```
 
 To run a single test:

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2031,7 +2031,9 @@ module Authlogic
 
       # @api private
       def set_last_request_at
-        current_time = klass.default_timezone == :utc ? Time.now.utc : Time.now
+        # current_time = klass.default_timezone == :utc ? Time.now.utc : Time.now
+        # current_time = ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
+        current_time = Time.current
         MagicColumn::AssignsLastRequestAt
           .new(current_time, record, controller, last_request_at_threshold)
           .assign

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2031,8 +2031,6 @@ module Authlogic
 
       # @api private
       def set_last_request_at
-        # current_time = klass.default_timezone == :utc ? Time.now.utc : Time.now
-        # current_time = ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
         current_time = Time.current
         MagicColumn::AssignsLastRequestAt
           .new(current_time, record, controller, last_request_at_threshold)

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -1354,7 +1354,6 @@ module Authlogic
       #
       # This is the method that the class level method find uses to ultimately
       # persist the session.
-      # rubocop:disable Metrics/AbcSize
       def persisting?
         return true unless record.nil?
         self.attempted_record = nil
@@ -1372,7 +1371,6 @@ module Authlogic
           false
         end
       end
-      # rubocop:enable Metrics/AbcSize
 
       def save_record(alternate_record = nil)
         r = alternate_record || record

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -1354,6 +1354,7 @@ module Authlogic
       #
       # This is the method that the class level method find uses to ultimately
       # persist the session.
+      # rubocop:disable Metrics/AbcSize
       def persisting?
         return true unless record.nil?
         self.attempted_record = nil
@@ -1371,6 +1372,7 @@ module Authlogic
           false
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def save_record(alternate_record = nil)
         r = alternate_record || record


### PR DESCRIPTION
This is in regard to Issue [742](https://github.com/binarylogic/authlogic/issues/742).

This is a proposal for how to solve the deprecation warning mentioned the issue, and is not ready to be merged.

The test suite runs fine for this PR for Rails 5.2, 6.0, 6.1 and 7.0.