### PR TITLE
Fix `default_timezone` depreciation warning in Rails 7

### DIFF
--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2092,7 +2092,7 @@ module Authlogic
       def update_login_timestamps
         if record.respond_to?(:current_login_at)
           record.last_login_at = record.current_login_at if record.respond_to?(:last_login_at)
-          record.current_login_at = klass.default_timezone == :utc ? Time.now.utc : Time.now
+          record.current_login_at = Time.current
         end
       end
 


### PR DESCRIPTION
Per #743, I changed the implementation of the current time in the same way for `#update_login_timestamps`, to get rid of the `ActiveRecord::Base.default_timezone` depreciation warning in Rails 7.0.