### PR TITLE
Check against rails 7 0 rc1

### DIFF
--- a/gemfiles/rails_7.0.rb
+++ b/gemfiles/rails_7.0.rb
@@ -5,5 +5,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 source "https://rubygems.org"
 gemspec path: ".."
 
-gem "activerecord", "~> 7.0.0.alpha", github: "rails/rails", branch: "main"
-gem "activesupport", "~> 7.0.0.alpha", github: "rails/rails", branch: "main"
+# For some reason, Rails 7.0.0.rc1 is tagged as 7.1.0.alpha
+gem "activerecord", "~> 7.1.0.alpha", github: "rails/rails", branch: "main"
+gem "activesupport", "~> 7.1.0.alpha", github: "rails/rails", branch: "main"

--- a/gemfiles/rails_7.0.rb
+++ b/gemfiles/rails_7.0.rb
@@ -5,6 +5,5 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 source "https://rubygems.org"
 gemspec path: ".."
 
-# For some reason, Rails 7.0.0.rc1 is tagged as 7.1.0.alpha
-gem "activerecord", "~> 7.1.0.alpha", github: "rails/rails", branch: "main"
-gem "activesupport", "~> 7.1.0.alpha", github: "rails/rails", branch: "main"
+gem "activerecord", "~> 7.0.0"
+gem "activesupport", "~> 7.0.0"

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2089,10 +2089,6 @@ module Authlogic
         end
       end
 
-      def a_r_default_timezone
-        (ActiveRecord.respond_to?(:default_timezone) ? ActiveRecord : klass).default_timezone
-      end
-
       def update_login_timestamps
         if record.respond_to?(:current_login_at)
           record.last_login_at = record.current_login_at if record.respond_to?(:last_login_at)

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2096,7 +2096,7 @@ module Authlogic
       def update_login_timestamps
         if record.respond_to?(:current_login_at)
           record.last_login_at = record.current_login_at if record.respond_to?(:last_login_at)
-          record.current_login_at = a_r_default_timezone == :utc ? Time.now.utc : Time.now
+          record.current_login_at = Time.current
         end
       end
 

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2092,7 +2092,7 @@ module Authlogic
       def update_login_timestamps
         if record.respond_to?(:current_login_at)
           record.last_login_at = record.current_login_at if record.respond_to?(:last_login_at)
-          record.current_login_at = klass.default_timezone == :utc ? Time.now.utc : Time.now
+          record.current_login_at = ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
         end
       end
 

--- a/lib/authlogic/session/base.rb
+++ b/lib/authlogic/session/base.rb
@@ -2089,10 +2089,14 @@ module Authlogic
         end
       end
 
+      def a_r_default_timezone
+        (ActiveRecord.respond_to?(:default_timezone) ? ActiveRecord : klass).default_timezone
+      end
+
       def update_login_timestamps
         if record.respond_to?(:current_login_at)
           record.last_login_at = record.current_login_at if record.respond_to?(:last_login_at)
-          record.current_login_at = ActiveRecord.default_timezone == :utc ? Time.now.utc : Time.now
+          record.current_login_at = a_r_default_timezone == :utc ? Time.now.utc : Time.now
         end
       end
 

--- a/test/acts_as_authentic_test/perishable_token_test.rb
+++ b/test/acts_as_authentic_test/perishable_token_test.rb
@@ -63,7 +63,7 @@ module ActsAsAuthenticTest
     def test_find_using_perishable_token_when_perished
       ben = users(:ben)
       ActiveRecord::Base.connection.execute(
-        "UPDATE users set updated_at = '#{1.week.ago.to_s(:db)}' where id = #{ben.id}"
+        "UPDATE users set updated_at = '#{1.week.ago.to_formatted_s(:db)}' where id = #{ben.id}"
       )
       assert_nil User.find_using_perishable_token(ben.perishable_token)
     end
@@ -72,7 +72,7 @@ module ActsAsAuthenticTest
       User.perishable_token_valid_for = 1.minute
       ben = users(:ben)
       ActiveRecord::Base.connection.execute(
-        "UPDATE users set updated_at = '#{2.minutes.ago.to_s(:db)}' where id = #{ben.id}"
+        "UPDATE users set updated_at = '#{2.minutes.ago.to_formatted_s(:db)}' where id = #{ben.id}"
       )
       assert_nil User.find_using_perishable_token(ben.perishable_token)
       User.perishable_token_valid_for = 10.minutes
@@ -82,7 +82,7 @@ module ActsAsAuthenticTest
       User.perishable_token_valid_for = 1.minute
       ben = users(:ben)
       ActiveRecord::Base.connection.execute(
-        "UPDATE users set updated_at = '#{10.minutes.ago.to_s(:db)}' where id = #{ben.id}"
+        "UPDATE users set updated_at = '#{10.minutes.ago.to_formatted_s(:db)}' where id = #{ben.id}"
       )
       assert_nil User.find_using_perishable_token(ben.perishable_token, 5.minutes)
       assert_equal ben, User.find_using_perishable_token(ben.perishable_token, 20.minutes)

--- a/test/session_test/brute_force_protection_test.rb
+++ b/test/session_test/brute_force_protection_test.rb
@@ -75,7 +75,8 @@ module SessionTest
         end
 
         ActiveRecord::Base.connection.execute(
-          "update users set updated_at = '#{1.day.ago.to_s(:db)}' where login = '#{ben.login}'"
+          "update users set updated_at = '#{1.day.ago.to_formatted_s(:db)}'
+           where login = '#{ben.login}'"
         )
         session = UserSession.new(login: ben.login, password: "benrocks")
         assert session.save
@@ -97,7 +98,8 @@ module SessionTest
         end
 
         ActiveRecord::Base.connection.execute(
-          "update users set updated_at = '#{1.day.ago.to_s(:db)}' where login = '#{ben.login}'"
+          "update users set updated_at = '#{1.day.ago.to_formatted_s(:db)}'
+           where login = '#{ben.login}'"
         )
         session = UserSession.new(login: ben.login, password: "badpassword1")
         refute session.save


### PR DESCRIPTION
This pull request has two changes:

1. Change the Rails 7 version to call 7.0.0.rc1.
2. Fix the underlying code to avoid a `default_timezone` depreciation warning.

All comments / questions welcome.