### PR TITLE
Add gemspec flag that requires MFA for gem privileged operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Breaking Changes
   * None
 * Added
-  * None
+  * Rubygems MFA requirement for authors added to gemspec.
 * Fixed
   * None
 

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -21,7 +21,7 @@ require "authlogic/version"
   s.homepage = "https://github.com/binarylogic/authlogic"
   s.summary = "An unobtrusive ruby authentication library based on ActiveRecord."
   s.license = "MIT"
-
+  s.metadata = { "rubygems_mfa_required" => "true" }
   s.required_ruby_version = ">= 2.6.0"
 
   # See doc/rails_support_in_authlogic_5.0.md


### PR DESCRIPTION
There's a [new feature in Rubygems](https://guides.rubygems.org/mfa-requirement-opt-in/) that lets you require MFA on privileged gem operations by setting metadata in your gemspec. Once this is pushed to Rubygems, it will enforce this flag.

It would also display the requirement on the gem page, e.g.:

![Screen Shot 2022-01-13 at 10 49 50 AM](https://user-images.githubusercontent.com/5054/149363701-7f0f1cbc-31c9-4c9c-8954-8d172179d28f.png)
