### PR TITLE
Rails 71

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       # have set this up with each database as a separate job, but then we'd be
       # duplicating the matrix configuration three times.
       matrix:
-        gemfile: [ 'rails_5.2', 'rails_6.0', 'rails_6.1', 'rails_7.0' ]
+        gemfile: [ 'rails_5.2', 'rails_6.0', 'rails_6.1', 'rails_7.0', 'rails_7.1' ]
 
         # To keep matrix size down, only test highest and lowest rubies. In
         # `.rubocopy.yml`, set `TargetRubyVersion`, to the lowest ruby version
@@ -67,6 +67,8 @@ jobs:
           # rails 7 requires ruby >= 2.7.0
           - ruby: '2.6'
             gemfile: 'rails_7.0'
+          - ruby: '2.6'
+            gemfile: 'rails_7.1'
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,10 @@ BUNDLE_GEMFILE=gemfiles/rails_6.1.rb bundle exec rake
 # Rails 7.0
 BUNDLE_GEMFILE=gemfiles/rails_7.0.rb bundle install
 BUNDLE_GEMFILE=gemfiles/rails_7.0.rb bundle exec rake
+
+# Rails 7.1
+BUNDLE_GEMFILE=gemfiles/rails_7.1.rb bundle install
+BUNDLE_GEMFILE=gemfiles/rails_7.1.rb bundle exec rake
 ```
 
 To run a single test:

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -25,13 +25,14 @@ require "authlogic/version"
   s.required_ruby_version = ">= 2.6.0"
 
   # See doc/rails_support_in_authlogic_5.0.md
-  s.add_dependency "activemodel", [">= 5.2", "< 7.1"]
-  s.add_dependency "activerecord", [">= 5.2", "< 7.1"]
-  s.add_dependency "activesupport", [">= 5.2", "< 7.1"]
+  s.add_dependency "activemodel", [">= 5.2", "< 7.2"]
+  s.add_dependency "activerecord", [">= 5.2", "< 7.2"]
+  s.add_dependency "activesupport", [">= 5.2", "< 7.2"]
   s.add_dependency "request_store", "~> 1.0"
   s.add_development_dependency "bcrypt", "~> 3.1"
   s.add_development_dependency "byebug", "~> 10.0"
   s.add_development_dependency "coveralls", "~> 0.8.22"
+  s.add_development_dependency "minitest", "< 5.19.0" # See https://github.com/binarylogic/authlogic/issues/766
   s.add_development_dependency "minitest-reporters", "~> 1.3"
   s.add_development_dependency "mysql2", "~> 0.5.2"
   s.add_development_dependency "pg", "~> 1.1.4"

--- a/gemfiles/rails_7.1.rb
+++ b/gemfiles/rails_7.1.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+source "https://rubygems.org"
+gemspec path: ".."
+
+gem "activerecord", "~> 7.1.0"
+gem "activesupport", "~> 7.1.0"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -62,7 +62,11 @@ if ActiveSupport.respond_to?(:test_order)
   ActiveSupport.test_order = :sorted
 end
 
-ActiveRecord::Base.default_timezone = :local
+if ActiveRecord::VERSION::STRING < "7.1"
+  ActiveRecord::Base.default_timezone = :local
+else
+  ActiveRecord.default_timezone = :local
+end
 ActiveRecord::Schema.define(version: 1) do
   create_table :companies do |t|
     t.datetime  :created_at, limit: 6


### PR DESCRIPTION
Relaxes the version constraints to allow compatibility with Rails 7.1.

Only incompatibility detected by tests was `default_timezone` is now set directly on `ActiveRecord` and not on `ActiveRecord::Base` - but that is only for the test setup and won't effect any usage of the gem.
