### PR TITLE
Load authlogic at the proper time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,20 +59,21 @@ jobs:
         # To keep matrix size down, only test highest and lowest rubies. In
         # `.rubocop.yml`, set `TargetRubyVersion`, to the lowest ruby version
         # tested here.
-        ruby: ["2.6", "3.3"]
-        rails: ["5.2", "6.0", "6.1", "7.0", "7.1", "7.2", "8.0"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        rails: ["7.0", "7.1", "7.2", "8.0"]
         exclude:
           # rails 7 requires ruby >= 2.7.0
-          - ruby: "2.6"
-            rails: "7.0"
-          - ruby: "2.6"
-            rails: "7.1"
-          - ruby: "2.6"
-            rails: "7.2"
-          - ruby: "2.6"
-            rails: "8.0"
-          - ruby: "3.3"
-            rails: "5.2"
+          - rails: "7.0"
+            ruby: "3.1"
+          - rails: "7.0"
+            ruby: "3.2"
+          - rails: "7.0"
+            ruby: "3.3"
+          - rails: "7.0"
+            ruby: "3.4"
+          - rails: "8.0"
+            ruby: "3.1"
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,8 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - name: Bundle
         run: |
-          gem install bundler -v 2.4.22
+          gem update --system
+          gem install bundler
           bundle install --jobs 4 --retry 3
         env:
           BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
+          bundler-cache: true
       # MySQL db was created above, sqlite will be created during test suite,
       # when migrations occur, so we only need to create the postgres db. I
       # tried something like `cd .....dummy_app && ....db:create`, but couldn't

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,11 +80,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Bundle
-        run: |
-          gem update --system
-          gem install bundler
-          bundle install --jobs 4 --retry 3
         env:
           BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,8 @@ jobs:
             ruby: "3.4"
           - rails: "8.0"
             ruby: "3.1"
-
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -81,8 +82,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-        env:
-          BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb
 
       # MySQL db was created above, sqlite will be created during test suite,
       # when migrations occur, so we only need to create the postgres db. I
@@ -106,13 +105,11 @@ jobs:
       - name: Test, sqlite
         run: bundle exec rake test
         env:
-          BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb
           DB: sqlite
       - name: Test, mysql
         run: bundle exec rake test
         env:
           BACKTRACE: 1
-          BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb
           DB: mysql
           AUTHLOGIC_DB_NAME: authlogic
           AUTHLOGIC_DB_USER: root
@@ -122,7 +119,6 @@ jobs:
         run: bundle exec rake test
         env:
           BACKTRACE: 1
-          BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.rb
           DB: postgres
           AUTHLOGIC_DB_NAME: authlogic
           AUTHLOGIC_DB_USER: postgres

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 require "English"
-$LOAD_PATH.push File.expand_path("lib", __dir__)
-require "authlogic/version"
+
+require_relative "lib/authlogic/version"
 
 ::Gem::Specification.new do |s|
   s.name = "authlogic"

--- a/authlogic.gemspec
+++ b/authlogic.gemspec
@@ -34,6 +34,7 @@ require "authlogic/version"
   s.add_development_dependency "coveralls_reborn", "~> 0.28.0"
   s.add_development_dependency "minitest", "< 5.19.0" # See https://github.com/binarylogic/authlogic/issues/766
   s.add_development_dependency "minitest-reporters", "~> 1.3"
+  s.add_development_dependency "mutex_m", "~> 0.3.0"
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rubocop", "~> 0.80.1"
   s.add_development_dependency "rubocop-performance", "~> 1.1"

--- a/lib/authlogic.rb
+++ b/lib/authlogic.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+require_relative "authlogic/errors"
+require_relative "authlogic/i18n"
+require_relative "authlogic/random"
+require_relative "authlogic/config"
+
+require_relative "authlogic/controller_adapters/abstract_adapter"
+require_relative "authlogic/cookie_credentials"
+
+require_relative "authlogic/crypto_providers"
+
+require_relative "authlogic/acts_as_authentic/email"
+require_relative "authlogic/acts_as_authentic/logged_in_status"
+require_relative "authlogic/acts_as_authentic/login"
+require_relative "authlogic/acts_as_authentic/magic_columns"
+require_relative "authlogic/acts_as_authentic/password"
+require_relative "authlogic/acts_as_authentic/perishable_token"
+require_relative "authlogic/acts_as_authentic/persistence_token"
+require_relative "authlogic/acts_as_authentic/session_maintenance"
+require_relative "authlogic/acts_as_authentic/single_access_token"
+require_relative "authlogic/acts_as_authentic/base"
+
+require_relative "authlogic/session/magic_column/assigns_last_request_at"
+require_relative "authlogic/session/base"
+
 # Authlogic uses ActiveSupport's core extensions like `strip_heredoc` and
 # `squish`. ActiveRecord does not `require` these exensions, so we must.
 #
@@ -8,37 +32,5 @@
 # decision if it becomes a problem.
 require "active_support/all"
 
-require "active_record"
-
-path = File.dirname(__FILE__) + "/authlogic/"
-
-[
-  "errors",
-  "i18n",
-  "random",
-  "config",
-
-  "controller_adapters/abstract_adapter",
-  "cookie_credentials",
-
-  "crypto_providers",
-
-  "acts_as_authentic/email",
-  "acts_as_authentic/logged_in_status",
-  "acts_as_authentic/login",
-  "acts_as_authentic/magic_columns",
-  "acts_as_authentic/password",
-  "acts_as_authentic/perishable_token",
-  "acts_as_authentic/persistence_token",
-  "acts_as_authentic/session_maintenance",
-  "acts_as_authentic/single_access_token",
-  "acts_as_authentic/base",
-
-  "session/magic_column/assigns_last_request_at",
-  "session/base"
-].each do |library|
-  require path + library
-end
-
-require path + "controller_adapters/rails_adapter"   if defined?(Rails)
-require path + "controller_adapters/sinatra_adapter" if defined?(Sinatra)
+require_relative "authlogic/controller_adapters/rails_adapter" if defined?(Rails)
+require_relative "authlogic/controller_adapters/sinatra_adapter" if defined?(Sinatra)

--- a/lib/authlogic/acts_as_authentic/base.rb
+++ b/lib/authlogic/acts_as_authentic/base.rb
@@ -104,13 +104,15 @@ module Authlogic
   end
 end
 
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Base
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Email
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::LoggedInStatus
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Login
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::MagicColumns
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Password
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::PerishableToken
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::PersistenceToken
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::SessionMaintenance
-::ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::SingleAccessToken
+ActiveSupport.on_load :active_record do
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Base
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Email
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::LoggedInStatus
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Login
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::MagicColumns
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::Password
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::PerishableToken
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::PersistenceToken
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::SessionMaintenance
+  ActiveRecord::Base.send :include, Authlogic::ActsAsAuthentic::SingleAccessToken
+end

--- a/lib/authlogic/acts_as_authentic/login.rb
+++ b/lib/authlogic/acts_as_authentic/login.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "authlogic/acts_as_authentic/queries/case_sensitivity"
-require "authlogic/acts_as_authentic/queries/find_with_case"
+require_relative "queries/case_sensitivity"
+require_relative "queries/find_with_case"
 
 module Authlogic
   module ActsAsAuthentic

--- a/lib/authlogic/i18n.rb
+++ b/lib/authlogic/i18n.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "authlogic/i18n/translator"
+require_relative "i18n/translator"
 
 module Authlogic
   # This class allows any message in Authlogic to use internationalization. In

--- a/lib/authlogic/test_case.rb
+++ b/lib/authlogic/test_case.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require File.dirname(__FILE__) + "/test_case/rails_request_adapter"
-require File.dirname(__FILE__) + "/test_case/mock_api_controller"
-require File.dirname(__FILE__) + "/test_case/mock_cookie_jar"
-require File.dirname(__FILE__) + "/test_case/mock_controller"
-require File.dirname(__FILE__) + "/test_case/mock_logger"
-require File.dirname(__FILE__) + "/test_case/mock_request"
+require_relative "test_case/rails_request_adapter"
+require_relative "test_case/mock_api_controller"
+require_relative "test_case/mock_cookie_jar"
+require_relative "test_case/mock_controller"
+require_relative "test_case/mock_logger"
+require_relative "test_case/mock_request"
 
 # :nodoc:
 module Authlogic

--- a/lib/authlogic/version.rb
+++ b/lib/authlogic/version.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rubygems"
-
 # :nodoc:
 module Authlogic
   # Returns a `::Gem::Version`, the version number of the authlogic gem.


### PR DESCRIPTION
This PR loads authlogic once Active Record has successfully loaded. It fixes an issue around eager loading in Rails 8 (possibly earlier versions too).

Closes https://github.com/binarylogic/authlogic/issues/776
Closes https://github.com/binarylogic/authlogic/issues/774
Fixes https://github.com/binarylogic/authlogic/issues/458