### PR TITLE
Replace deprecated ActiveRecord::Base.connection via with_connection

### DIFF
--- a/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
+++ b/lib/authlogic/acts_as_authentic/queries/find_with_case.rb
@@ -42,17 +42,21 @@ module Authlogic
 
         # @api private
         def insensitive_comparison
-          @model_class.connection.case_insensitive_comparison(
-            @model_class.arel_table[@field], @value
-          )
+          @model_class.with_connection do |connection|
+            connection.case_insensitive_comparison(
+              @model_class.arel_table[@field], @value
+            )
+          end
         end
 
         # @api private
         def sensitive_comparison
           bound_value = @model_class.predicate_builder.build_bind_attribute(@field, @value)
-          @model_class.connection.case_sensitive_comparison(
-            @model_class.arel_table[@field], bound_value
-          )
+          @model_class.with_connection do |connection|
+            connection.case_sensitive_comparison(
+              @model_class.arel_table[@field], bound_value
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Rails soft-deprecated `ActiveRecord::Base.connection` in favor of `with_connection`, this PR updates authlogic to this new change.
  
relevant activerecord changes:
- ([rails/rails#51230](https://github.com/rails/rails/pull/51230))
- ([rails/rails#51349](https://github.com/rails/rails/pull/51349))
